### PR TITLE
Run containers in a safer way

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -41,10 +40,6 @@ var dockerClient DockerClient
 const (
 	// The path in which the Docker client is listening to.
 	dockerSocket = "unix:///var/run/docker.sock"
-
-	// The name of the temporary container created in the
-	// `runCommandInContainer` function.
-	temporaryName = "zypper-docker-private"
 
 	// The timeout in which the container is allowed to run a command as given
 	// to the `runCommandInContainer` function.
@@ -80,9 +75,8 @@ func runCommandInContainer(img string, cmd []string) bool {
 	client := getDockerClient()
 
 	// First of all we create a container in which we will run the command.
-	config := &dockerclient.ContainerConfig{Image: img, Cmd: cmd}
-	name := fmt.Sprintf("%s-%s", temporaryName, img)
-	id, err := client.CreateContainer(config, name)
+	config := &dockerclient.ContainerConfig{Image: img, Entrypoint: cmd}
+	id, err := client.CreateContainer(config, "")
 	if err != nil {
 		log.Println(err)
 		return false

--- a/mock_test.go
+++ b/mock_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -81,6 +82,8 @@ func (mc *mockClient) CreateContainer(config *dockerclient.ContainerConfig, name
 	if mc.createFail {
 		return "", errors.New("Create failed")
 	}
+	name = fmt.Sprintf("zypper-docker-private-%s", config.Image)
+
 	return name, nil
 }
 


### PR DESCRIPTION
Do not create the name of the container manually, this could lead to
invalid names when images have '/' symbol inside of them.

Also we have to use the entrypoint and not the command to start
zypper/whatever. This is required to overload the default entrypoint
some containers might have.