### PR TITLE
Implement zypper list updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ have been implemented:
 
 - [ ] Global options should be respected.
 - [x] List all the available images.
-- [ ] List all the available updates.
+- [x] List all the available updates.
 - [ ] List all the available patches.
 - [ ] Checking patches.
 - [ ] Installing patches.

--- a/mock_test.go
+++ b/mock_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/mssola/dockerclient"
 )
 
+var exitInvocations int
+
 type mockClient struct {
 	createFail  bool
 	removeFail  bool

--- a/updates.go
+++ b/updates.go
@@ -14,13 +14,27 @@
 
 package main
 
-import "github.com/codegangsta/cli"
+import (
+	"github.com/codegangsta/cli"
+	"log"
+)
 
-func listPatchescmd(ctx *cli.Context) {
-}
-func patchCmd(ctx *cli.Context) {
-}
-func patchCheckCmd(ctx *cli.Context) {
-}
-func psCmd(ctx *cli.Context) {
+func listUpdatesCmd(ctx *cli.Context) {
+	imageName := ctx.Args().First()
+
+	if imageName == "" {
+		log.Printf("Error: no image name specified\n")
+		exitWithCode(1)
+	}
+
+	id, err := runCommandInContainer(
+		imageName,
+		[]string{"/bin/sh", "-c", "zypper ref && zypper lu"},
+		true)
+	removeContainer(id)
+
+	if err != nil {
+		log.Printf("Error: %s\n", err)
+		exitWithCode(1)
+	}
 }

--- a/updates_test.go
+++ b/updates_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/codegangsta/cli"
+)
+
+func setupTestUpdates() {
+	exitInvocations = 0
+
+	if exitWithCode == nil {
+		exitWithCode = func(code int) {
+			exitInvocations += 1
+		}
+	}
+}
+
+func testListUpdatesContext(image string) *cli.Context {
+	set := flag.NewFlagSet("test", 0)
+	err := set.Parse([]string{image})
+	if err != nil {
+		log.Fatal("Cannot parse cli options", err)
+	}
+	return cli.NewContext(nil, set, nil)
+}
+
+func TestListUpdatesNoImageSpecified(t *testing.T) {
+	setupTestUpdates()
+	dockerClient = &mockClient{}
+
+	buffer := bytes.NewBuffer([]byte{})
+	log.SetOutput(buffer)
+
+	listUpdatesCmd(testListUpdatesContext(""))
+
+	if exitInvocations != 1 {
+		t.Fatalf("Expected to have exited with error")
+	}
+
+	if !strings.Contains(buffer.String(), "Error: no image name specified") {
+		t.Fatal("It should've logged something\n")
+	}
+}
+
+func TestListUpdatesCommandFailure(t *testing.T) {
+	setupTestUpdates()
+	dockerClient = &mockClient{commandFail: true}
+
+	buffer := bytes.NewBuffer([]byte{})
+	log.SetOutput(buffer)
+
+	listUpdatesCmd(testListUpdatesContext("opensuse:13.2"))
+
+	if !strings.Contains(buffer.String(), "Error: Command exited with status 1") {
+		t.Fatal("It should've logged something\n")
+	}
+	if exitInvocations != 1 {
+		t.Fatalf("Expected to have exited with error")
+	}
+}

--- a/zypper-docker.go
+++ b/zypper-docker.go
@@ -21,7 +21,13 @@ import (
 	"os"
 )
 
+var exitWithCode func(code int)
+
 func main() {
+	exitWithCode = func(code int) {
+		os.Exit(code)
+	}
+
 	log.SetOutput(os.Stderr)
 
 	// Safe initialization of the singleton client instance. Take a look at the


### PR DESCRIPTION
Everything is working as expected.

The command does not check whether the image has zypper or not. If there's no zypper the command will fail with a nice explanation message.