### PR TITLE
Let the `cachePath` function handle variables with multiple paths

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const cacheName = "docker-zypper.json"
@@ -118,10 +119,14 @@ func cachePath() *os.File {
 		if dir == "" {
 			continue
 		}
-		name := filepath.Join(dir, cacheName)
-		file, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE, 0666)
-		if err == nil {
-			return file
+
+		dirs := strings.Split(dir, ":")
+		for _, d := range dirs {
+			name := filepath.Join(d, cacheName)
+			file, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE, 0666)
+			if err == nil {
+				return file
+			}
 		}
 	}
 	return nil

--- a/cache_test.go
+++ b/cache_test.go
@@ -91,6 +91,29 @@ func TestCachePathFail(t *testing.T) {
 	}
 }
 
+func TestCachePathMultiple(t *testing.T) {
+	cache := os.Getenv("XDG_CACHE_HOME")
+	abs, _ := filepath.Abs(".")
+	test := filepath.Join(abs, "test")
+
+	defer func() {
+		_ = os.Setenv("XDG_CACHE_HOME", cache)
+	}()
+
+	_ = os.Setenv("XDG_CACHE_HOME", fmt.Sprintf("%v:%v", test, abs))
+	file := cachePath()
+	if file == nil {
+		t.Fatal("It should've been successful")
+	}
+	name, path := file.Name(), filepath.Join(test, cacheName)
+	_ = file.Close()
+	_ = os.Remove(path)
+
+	if name != path {
+		t.Fatal("Wrong name!")
+	}
+}
+
 func TestCacheBadJson(t *testing.T) {
 	cache := os.Getenv("XDG_CACHE_HOME")
 	abs, _ := filepath.Abs(".")


### PR DESCRIPTION
Some environment variables such as `XDG_DATA_DIRS` may contain multiple paths
in it separated by ':'. This commit makes the `cachePath` function aware of
this situation.

Fixes #11