### PR TITLE
Handle signals on the host

### DIFF
--- a/mock_test.go
+++ b/mock_test.go
@@ -37,6 +37,7 @@ type mockClient struct {
 	listFail    bool
 	listEmpty   bool
 	logFail     bool
+	killFail    bool
 }
 
 func (mc *mockClient) ListImages(all bool) ([]*dockerclient.Image, error) {
@@ -146,4 +147,11 @@ func (mc *mockClient) ContainerLogs(id string, options *dockerclient.LogOptions)
 	cb := &closingBuffer{bytes.NewBuffer([]byte{})}
 	_, err := cb.WriteString("streaming buffer initialized\n")
 	return cb, err
+}
+
+func (mc *mockClient) KillContainer(id, signal string) error {
+	if mc.killFail {
+		return fmt.Errorf("Fake failure while killing container")
+	}
+	return nil
 }


### PR DESCRIPTION
zypper-docker should handle singnals. For example: when `zypper-docker lu`
is running a SIGINT signal should be propagated to the container and then to zypper-docker itself.

Fixes #17