### PR TITLE
Implemet the update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ have been implemented:
 - [x] List all the available patches.
 - [x] Checking patches.
 - [x] Installing patches.
-- [ ] Install updates.
+- [x] Install updates.
 
 ## Generic operations
 

--- a/client.go
+++ b/client.go
@@ -277,3 +277,22 @@ func commitContainerToImage(containerId, repo, tag, comment, author string) erro
 	_, err := client.Commit(containerId, &dockerclient.ContainerConfig{}, repo, tag, comment, author)
 	return err
 }
+
+// Spawns a container from the specified image, runs the specified command inside
+// of it and commits the results to a new image.
+// The name of the new image is specified via target_repo and target_tag.
+// The container is always deleted.
+// If something goes wrong an error message is returned.
+func runCommandAndCommitToImage(img, target_repo, target_tag, cmd, comment, author string) error {
+	containerId, err := runCommandInContainer(img, []string{"/bin/sh", "-c", cmd}, true)
+	if err != nil {
+		return err
+	}
+
+	err = commitContainerToImage(containerId, target_repo, target_tag, comment, author)
+
+	// always remove the container
+	removeContainer(containerId)
+
+	return err
+}

--- a/client_test.go
+++ b/client_test.go
@@ -278,3 +278,66 @@ func TestHandleSignalWhileContainerRunsEvenWhenKillContainerFails(t *testing.T) 
 		t.Fatal("os.Exit should have been called by the client code\n")
 	}
 }
+
+func TestRunCommandAndCommitToImageSuccess(t *testing.T) {
+	dockerClient = &mockClient{}
+	var err error
+
+	capture.All(func() {
+		err = runCommandAndCommitToImage(
+			"source",
+			"new_repo",
+			"new_tag",
+			"touch foo",
+			"comment",
+			"author")
+	})
+
+	if err != nil {
+		t.Fatalf("Unexpected error")
+	}
+}
+
+func TestRunCommandAndCommitToImageRunFailure(t *testing.T) {
+	dockerClient = &mockClient{startFail: true}
+	var err error
+
+	capture.All(func() {
+		err = runCommandAndCommitToImage(
+			"source",
+			"new_repo",
+			"new_tag",
+			"touch foo",
+			"comment",
+			"author")
+	})
+
+	if err == nil {
+		t.Fatalf("No error")
+	}
+	if !strings.Contains(err.Error(), "Start failed") {
+		t.Fatalf("Wrong error")
+	}
+}
+
+func TestRunCommandAndCommitToImageCommitFailure(t *testing.T) {
+	dockerClient = &mockClient{commitFail: true}
+	var err error
+
+	capture.All(func() {
+		err = runCommandAndCommitToImage(
+			"source",
+			"new_repo",
+			"new_tag",
+			"touch foo",
+			"comment",
+			"author")
+	})
+
+	if err == nil {
+		t.Fatalf("No error")
+	}
+	if !strings.Contains(err.Error(), "Fake failure while committing container") {
+		t.Fatalf("Wrong error")
+	}
+}

--- a/flags.go
+++ b/flags.go
@@ -74,6 +74,22 @@ func newApp() *cli.App {
 			Action:  listUpdatesCmd,
 		},
 		{
+			Name:    "update",
+			Aliases: []string{"up"},
+			Usage:   "Install the available updates",
+			Action:  updateCmd,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "l, auto-agree-with-licenses:",
+					Usage: "Automatically say yes to third party license confirmation prompt. By using this option, you choose to agree with licenses of all third-party software this command will install.",
+				},
+				cli.BoolFlag{
+					Name:  "no-recommends",
+					Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
+				},
+			},
+		},
+		{
 			Name:    "list-patches",
 			Aliases: []string{"lp"},
 			Usage:   "List all the available patches",

--- a/flags_test.go
+++ b/flags_test.go
@@ -28,7 +28,7 @@ func TestNewApp(t *testing.T) {
 	if len(app.Flags) != 4 {
 		t.Fatal("Wrong number of global flags")
 	}
-	if len(app.Commands) != 6 {
+	if len(app.Commands) != 7 {
 		t.Fatal("Wrong number of subcommands")
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/codegangsta/cli"
+)
+
+// It appends the set flags with the given command.
+func cmdWithFlags(cmd string, ctx *cli.Context) string {
+	for _, name := range ctx.FlagNames() {
+		if value := ctx.String(name); value != "" {
+			var dash string
+			if len(name) == 1 {
+				dash = "-"
+			} else {
+				dash = "--"
+			}
+
+			if ctx.Bool(name) == false && ctx.IsSet(name) {
+				// this cannot be a false boolean flag
+				cmd += fmt.Sprintf(" %v%s %s", dash, name, value)
+			} else if ctx.Bool(name) {
+				// This is a boolean flag set to true
+				cmd += fmt.Sprintf(" %v%s", dash, name)
+			}
+			// else this is a false boolean flag, we just omit it
+		}
+	}
+	return cmd
+}
+
+// Given a Docker image name it returns the repository and the tag composing it
+// Returns the repository and the tag strings.
+// Examples:
+//   * suse/sles11sp3:1.0.0 -> repo is suse/sles11sp3, tag is 1.0.0
+//   * suse/sles11sp3 -> repo is suse/sles11sp3, tag is latest
+func parseImageName(name string) (string, string) {
+	var repo, tag string
+	target := strings.SplitN(name, ":", 2)
+	repo = target[0]
+	if len(target) != 2 {
+		tag = "latest"
+	} else {
+		tag = target[1]
+	}
+
+	return repo, tag
+}
+
+// Exists with error if the image identified by repo and tag already exists
+// Returns an error when the image already exists or something went wrong.
+func preventImageOverwrite(repo, tag string) error {
+	imageExists, err := checkImageExists(repo, tag)
+	if err != nil {
+		return err
+	}
+	if imageExists {
+		return fmt.Errorf("Cannot overwrite an existing image. Please use a different repository/tag.")
+	}
+	return nil
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseImageName(t *testing.T) {
+	// map with name as value and a string list with two enteries (repo and tag)
+	// as value
+	data := make(map[string][]string)
+	data["opensuse:13.2"] = []string{"opensuse", "13.2"}
+	data["opensuse"] = []string{"opensuse", "latest"}
+
+	for name, expected := range data {
+		repo, tag := parseImageName(name)
+		if repo != expected[0] {
+			t.Fatalf("repository %s is different from the expected %s", repo, expected[0])
+		}
+		if tag != expected[1] {
+			t.Fatalf("tag %s is different from the expected %s", tag, expected[1])
+		}
+	}
+}
+
+func TestPreventImageOverwriteImageCheckImageFailure(t *testing.T) {
+	dockerClient = &mockClient{listFail: true}
+
+	err := preventImageOverwrite("opensuse", "13.2")
+
+	if err == nil {
+		t.Fatalf("Expected error")
+	}
+	if !strings.Contains(err.Error(), "List Failed") {
+		t.Fatal("Wrong error message")
+	}
+}
+
+func TestPreventImageOverwriteImageExists(t *testing.T) {
+	dockerClient = &mockClient{}
+
+	err := preventImageOverwrite("opensuse", "13.2")
+
+	if err == nil {
+		t.Fatalf("Expected error")
+	}
+	if !strings.Contains(err.Error(), "Cannot overwrite an existing image.") {
+		t.Fatal("Wrong error message")
+	}
+}

--- a/patches_test.go
+++ b/patches_test.go
@@ -111,35 +111,25 @@ func TestPatchCommandWrongInvocation(t *testing.T) {
 	}
 }
 
-func TestPatchCommandCommitFailure(t *testing.T) {
+func TestPatchCommandImageOverwriteDetected(t *testing.T) {
 	setupTestExitStatus()
-	dockerClient = &mockClient{commitFail: true}
+	dockerClient = &mockClient{listFail: true}
 
-	buffer := bytes.NewBuffer([]byte{})
-	log.SetOutput(buffer)
 	capture.All(func() { patchCmd(testPatchContext("ori", "new:1.0.0")) })
 
 	if exitInvocations != 1 {
 		t.Fatalf("Expected to have exited with error")
-	}
-	if !strings.Contains(buffer.String(), "Fake failure while committing container") {
-		t.Fatal("It should've logged something\n")
 	}
 }
 
-func TestPatchCommandRunFailure(t *testing.T) {
+func TestPatchCommandRunAndCommitFailure(t *testing.T) {
 	setupTestExitStatus()
 	dockerClient = &mockClient{startFail: true}
 
-	buffer := bytes.NewBuffer([]byte{})
-	log.SetOutput(buffer)
 	capture.All(func() { patchCmd(testPatchContext("ori", "new:1.0.0")) })
 
 	if exitInvocations != 1 {
 		t.Fatalf("Expected to have exited with error")
-	}
-	if !strings.Contains(buffer.String(), "Start failed") {
-		t.Fatal("It should've logged something\n")
 	}
 }
 
@@ -155,54 +145,6 @@ func TestPatchCommandCommitSuccess(t *testing.T) {
 		t.Fatalf("Expected to have exited successfully")
 	}
 	if !strings.Contains(buffer.String(), "new:1.0.0 successfully created") {
-		t.Fatal("It should've logged something\n")
-	}
-}
-
-func TestPatchCommandCommitSuccessImplicitLatestTag(t *testing.T) {
-	setupTestExitStatus()
-	dockerClient = &mockClient{}
-
-	buffer := bytes.NewBuffer([]byte{})
-	log.SetOutput(buffer)
-	capture.All(func() { patchCmd(testPatchContext("ori", "new")) })
-
-	if exitInvocations != 0 {
-		t.Fatalf("Expected to have exited successfully")
-	}
-	if !strings.Contains(buffer.String(), "new:latest successfully created") {
-		t.Fatal("It should've logged something\n")
-	}
-}
-
-func TestPatchCommandCheckImageFailure(t *testing.T) {
-	setupTestExitStatus()
-	dockerClient = &mockClient{listFail: true}
-
-	buffer := bytes.NewBuffer([]byte{})
-	log.SetOutput(buffer)
-	capture.All(func() { patchCmd(testPatchContext("foo:1.0.0", "foo:1.0.1")) })
-
-	if exitInvocations != 1 {
-		t.Fatalf("Expected to have exited with error")
-	}
-	if !strings.Contains(buffer.String(), "List Failed") {
-		t.Fatal("It should've logged something\n")
-	}
-}
-
-func TestPatchCommandExitWhenTargetOverwritesExistingImage(t *testing.T) {
-	setupTestExitStatus()
-	dockerClient = &mockClient{}
-
-	buffer := bytes.NewBuffer([]byte{})
-	log.SetOutput(buffer)
-	capture.All(func() { patchCmd(testPatchContext("foo:1.0.0", "opensuse:13.2")) })
-
-	if exitInvocations != 1 {
-		t.Fatalf("Expected to have exited with error")
-	}
-	if !strings.Contains(buffer.String(), "Cannot overwrite an existing image.") {
 		t.Fatal("It should've logged something\n")
 	}
 }


### PR DESCRIPTION
The `update` command installs all the pending updates.

Some refactoring has been done because the `patch` and `update` commands have a lot in common.

Note well: I had to make some changes to the `cmdWithFlags` to make it work with boolean cli options. I'm not happy with the current code: this code feels a bit magic. I think we should look into handling the command line flags in a more manual way on a sub-command basis. This would ensure nothing unexpected happens during the "magic" conversion.

However that should be handled with another PR.