### PR TITLE
Flags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -80,7 +80,7 @@ func newApp() *cli.App {
 			Action:  updateCmd,
 			Flags: []cli.Flag{
 				cli.BoolFlag{
-					Name:  "l, auto-agree-with-licenses:",
+					Name:  "l, auto-agree-with-licenses",
 					Usage: "Automatically say yes to third party license confirmation prompt. By using this option, you choose to agree with licenses of all third-party software this command will install.",
 				},
 				cli.BoolFlag{
@@ -146,6 +146,14 @@ func newApp() *cli.App {
 					Name:  "issues",
 					Value: "",
 					Usage: "Look for issues whose number, summary, or description matches the specified string.",
+				},
+				cli.BoolFlag{
+					Name:  "l, auto-agree-with-licenses",
+					Usage: "Automatically say yes to third party license confirmation prompt. By using this option, you choose to agree with licenses of all third-party software this command will install.",
+				},
+				cli.BoolFlag{
+					Name:  "no-recommends",
+					Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
 				},
 			},
 		},

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -15,8 +15,11 @@
 package main
 
 import (
+	"flag"
 	"strings"
 	"testing"
+
+	"github.com/codegangsta/cli"
 )
 
 func TestParseImageName(t *testing.T) {
@@ -60,5 +63,54 @@ func TestPreventImageOverwriteImageExists(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Cannot overwrite an existing image.") {
 		t.Fatal("Wrong error message")
+	}
+}
+
+func TestCmdWithFlags(t *testing.T) {
+	cmd := cli.Command{
+		Name:  "lp",
+		Usage: "List all the images based on either OpenSUSE or SLES",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "b, bugzilla",
+				Value: "",
+				Usage: "List available needed patches for all Bugzilla issues, or issues whose number matches the given string.",
+			},
+			cli.StringFlag{
+				Name:  "cve",
+				Value: "",
+				Usage: "List available needed patches for all CVE issues, or issues whose number matches the given string.",
+			},
+			cli.BoolFlag{
+				Name:  "l, auto-agree-with-licenses",
+				Usage: "Automatically say yes to third party license confirmation prompt. By using this option, you choose to agree with licenses of all third-party software this command will install.",
+			},
+			cli.BoolFlag{
+				Name:  "no-recommends",
+				Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
+			},
+			cli.BoolFlag{
+				Name:  "explode",
+				Usage: "Boom",
+			},
+		},
+	}
+
+	set := flag.NewFlagSet("test", 0)
+	set.String("b", "bugzilla_value", "doc")
+	set.String("cve", "cve_value", "doc")
+	set.Bool("l", true, "doc")
+	set.Bool("no-recommends", true, "doc")
+	set.Bool("explode", false, "doc")
+
+	ctx := cli.NewContext(nil, set, nil)
+	ctx.Command = cmd
+
+	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends", "explode"}
+	actual := cmdWithFlags("cmd", ctx, boolFlags)
+	expected := "cmd -b bugzilla_value --cve cve_value -l --no-recommends"
+
+	if expected != actual {
+		t.Fatal("Wrong command")
 	}
 }

--- a/images_test.go
+++ b/images_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"log"
 	"os"
 	"path/filepath"
@@ -24,15 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codegangsta/cli"
 	"github.com/mssola/capture"
 )
-
-func testContext(force bool) *cli.Context {
-	set := flag.NewFlagSet("test", 0)
-	set.Bool("force", force, "doc")
-	return cli.NewContext(nil, set, nil)
-}
 
 func TestMain(m *testing.M) {
 	status := 0
@@ -59,7 +51,7 @@ func TestImagesCmdFail(t *testing.T) {
 
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
-	imagesCmd(testContext(false))
+	imagesCmd(testContext([]string{}, false))
 
 	lines := strings.Split(buffer.String(), "\n")
 	if len(lines) != 2 {
@@ -77,7 +69,7 @@ func TestImagesListEmpty(t *testing.T) {
 	dockerClient = &mockClient{listEmpty: true}
 	setupTestExitStatus()
 
-	res := capture.All(func() { imagesCmd(testContext(false)) })
+	res := capture.All(func() { imagesCmd(testContext([]string{}, false)) })
 
 	lines := strings.Split(string(res.Stdout), "\n")
 	if len(lines) != 3 {
@@ -98,7 +90,7 @@ func TestImagesListOk(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
 
-	res := capture.All(func() { imagesCmd(testContext(false)) })
+	res := capture.All(func() { imagesCmd(testContext([]string{}, false)) })
 
 	lines := strings.Split(string(res.Stdout), "\n")
 	if len(lines) != 6 {
@@ -149,7 +141,7 @@ func TestImagesForce(t *testing.T) {
 	}
 
 	// Luke, use the force!
-	capture.All(func() { imagesCmd(testContext(true)) })
+	capture.All(func() { imagesCmd(testContext([]string{}, true)) })
 	cd = getCacheFile()
 
 	if !cd.Valid {

--- a/patch_check_test.go
+++ b/patch_check_test.go
@@ -29,7 +29,7 @@ func TestPatchCheckNoImageSpecified(t *testing.T) {
 
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
-	capture.All(func() { patchCheckCmd(testListUpdatesContext("")) })
+	capture.All(func() { patchCheckCmd(testContext([]string{}, false)) })
 
 	if testCommand() != "" {
 		t.Fatalf("The command should not have been executed")
@@ -52,7 +52,7 @@ func TestPatchCheckInvalidError(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
 	capture.All(func() {
-		patchCheckCmd(testListUpdatesContext("opensuse:13.2"))
+		patchCheckCmd(testContext([]string{"opensuse:13.2"}, false))
 	})
 
 	if testCommand() != "zypper pchk" {
@@ -73,7 +73,7 @@ func TestPatchCheckSupportedNonZeroExit(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
 	capture.All(func() {
-		patchCheckCmd(testListUpdatesContext("opensuse:13.2"))
+		patchCheckCmd(testContext([]string{"opensuse:13.2"}, false))
 	})
 
 	if testCommand() != "zypper pchk" {
@@ -91,7 +91,7 @@ func TestPatchCheckOk(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
 	capture.All(func() {
-		patchCheckCmd(testListUpdatesContext("opensuse:13.2"))
+		patchCheckCmd(testContext([]string{"opensuse:13.2"}, false))
 	})
 
 	if testCommand() != "zypper pchk" {

--- a/patches.go
+++ b/patches.go
@@ -26,7 +26,7 @@ import (
 func listPatchesCmd(ctx *cli.Context) {
 	// It's safe to ignore the returned error because we set to false the
 	// `getError` parameter of this function.
-	_ = runStreamedCommand(ctx.Args().First(), cmdWithFlags("lp", ctx), false)
+	_ = runStreamedCommand(ctx.Args().First(), cmdWithFlags("lp", ctx, []string{}), false)
 }
 
 // zypper-docker patch [flags] image
@@ -47,7 +47,11 @@ func patchCmd(ctx *cli.Context) {
 	comment := "[zypper-docker] apply patches"
 	author := os.Getenv("USER")
 
-	cmd := fmt.Sprintf("zypper ref && zypper -n %v", cmdWithFlags("patch", ctx))
+	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
+
+	cmd := fmt.Sprintf(
+		"zypper ref && zypper -n %v",
+		cmdWithFlags("patch", ctx, boolFlags))
 	err := runCommandAndCommitToImage(
 		img,
 		repo,

--- a/patches_test.go
+++ b/patches_test.go
@@ -60,7 +60,7 @@ func TestListPatchesNoImageSpecified(t *testing.T) {
 
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
-	capture.All(func() { listPatchesCmd(testListUpdatesContext("")) })
+	capture.All(func() { listPatchesCmd(testContext([]string{}, false)) })
 
 	if testCommand() != "" {
 		t.Fatalf("The command should not have been executed")
@@ -81,7 +81,7 @@ func TestListPatchesCommandFailure(t *testing.T) {
 	log.SetOutput(buffer)
 
 	capture.All(func() {
-		listPatchesCmd(testListUpdatesContext("opensuse:13.2"))
+		listPatchesCmd(testContext([]string{"opensuse:13.2"}, false))
 	})
 
 	if testCommand() != "zypper lp" {

--- a/test_helper.go
+++ b/test_helper.go
@@ -14,7 +14,13 @@
 
 package main
 
-import "bytes"
+import (
+	"bytes"
+	"flag"
+	"log"
+
+	"github.com/codegangsta/cli"
+)
 
 var exitInvocations, lastCode int
 
@@ -36,4 +42,15 @@ type closingBuffer struct {
 
 func (cb *closingBuffer) Close() error {
 	return nil
+}
+
+func testContext(args []string, force bool) *cli.Context {
+	set := flag.NewFlagSet("test", 0)
+	c := cli.NewContext(nil, set, nil)
+	set.Bool("force", force, "doc")
+	err := set.Parse(args)
+	if err != nil {
+		log.Fatal("Cannot parse cli options", err)
+	}
+	return c
 }

--- a/updates.go
+++ b/updates.go
@@ -45,7 +45,10 @@ func updateCmd(ctx *cli.Context) {
 	comment := "[zypper-docker] apply updates"
 	author := os.Getenv("USER")
 
-	cmd := fmt.Sprintf("zypper ref && zypper -n %v", cmdWithFlags("up", ctx))
+	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
+	cmd := fmt.Sprintf(
+		"zypper ref && zypper -n %v",
+		cmdWithFlags("up", ctx, boolFlags))
 	err := runCommandAndCommitToImage(
 		img,
 		repo,


### PR DESCRIPTION
Several clean-ups to fix issue #25. The `cmdWithFlags` now feels less magical, also it's test coverage is finally up to 100%.

I also consolidated the test methods used to allocate the cli flags inside of the different test files.

I don't think we have to spend resources making sure unsopported flags are detected, this is provided by the `cli` module, which has its own tests. Writing our own tests would be just a duplication.