### PR TITLE
Allow user to specify commit author and message

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -87,6 +87,16 @@ func newApp() *cli.App {
 					Name:  "no-recommends",
 					Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
 				},
+				cli.StringFlag{
+					Name:   "author",
+					EnvVar: "USERNAME",
+					Usage:  "Commit author to associate with the new layer (e.g., \"John Doe <john.doe@example.com>\")",
+				},
+				cli.StringFlag{
+					Name:  "message",
+					Value: "[zypper-docker] update",
+					Usage: "Commit message to associated with the new layer",
+				},
 			},
 		},
 		{
@@ -154,6 +164,16 @@ func newApp() *cli.App {
 				cli.BoolFlag{
 					Name:  "no-recommends",
 					Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
+				},
+				cli.StringFlag{
+					Name:   "author",
+					EnvVar: "USERNAME",
+					Usage:  "Commit author to associate with the new layer (e.g., \"John Doe <john.doe@example.com>\")",
+				},
+				cli.StringFlag{
+					Name:  "message",
+					Value: "[zypper-docker] patch",
+					Usage: "Commit message to associated with the new layer",
 				},
 			},
 		},

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -81,6 +81,11 @@ func TestCmdWithFlags(t *testing.T) {
 				Value: "",
 				Usage: "List available needed patches for all CVE issues, or issues whose number matches the given string.",
 			},
+			cli.StringFlag{
+				Name:  "to-ignore",
+				Value: "",
+				Usage: "Should not be forwarded.",
+			},
 			cli.BoolFlag{
 				Name:  "l, auto-agree-with-licenses",
 				Usage: "Automatically say yes to third party license confirmation prompt. By using this option, you choose to agree with licenses of all third-party software this command will install.",
@@ -99,6 +104,7 @@ func TestCmdWithFlags(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.String("b", "bugzilla_value", "doc")
 	set.String("cve", "cve_value", "doc")
+	set.String("to-ignore", "to_ignore_value", "doc")
 	set.Bool("l", true, "doc")
 	set.Bool("no-recommends", true, "doc")
 	set.Bool("explode", false, "doc")
@@ -107,7 +113,8 @@ func TestCmdWithFlags(t *testing.T) {
 	ctx.Command = cmd
 
 	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends", "explode"}
-	actual := cmdWithFlags("cmd", ctx, boolFlags)
+	toIgnore := []string{"to-ignore"}
+	actual := cmdWithFlags("cmd", ctx, boolFlags, toIgnore)
 	expected := "cmd -b bugzilla_value --cve cve_value -l --no-recommends"
 
 	if expected != actual {

--- a/patches.go
+++ b/patches.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/codegangsta/cli"
 )
@@ -26,7 +25,9 @@ import (
 func listPatchesCmd(ctx *cli.Context) {
 	// It's safe to ignore the returned error because we set to false the
 	// `getError` parameter of this function.
-	_ = runStreamedCommand(ctx.Args().First(), cmdWithFlags("lp", ctx, []string{}), false)
+	_ = runStreamedCommand(
+		ctx.Args().First(),
+		cmdWithFlags("lp", ctx, []string{}, []string{}), false)
 }
 
 // zypper-docker patch [flags] image
@@ -44,14 +45,15 @@ func patchCmd(ctx *cli.Context) {
 		exitWithCode(1)
 	}
 
-	comment := "[zypper-docker] apply patches"
-	author := os.Getenv("USER")
+	comment := ctx.String("message")
+	author := ctx.String("author")
 
 	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
+	toIgnore := []string{"author", "message"}
 
 	cmd := fmt.Sprintf(
 		"zypper ref && zypper -n %v",
-		cmdWithFlags("patch", ctx, boolFlags))
+		cmdWithFlags("patch", ctx, boolFlags, toIgnore))
 	err := runCommandAndCommitToImage(
 		img,
 		repo,

--- a/updates.go
+++ b/updates.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/codegangsta/cli"
 )
@@ -42,13 +41,15 @@ func updateCmd(ctx *cli.Context) {
 		exitWithCode(1)
 	}
 
-	comment := "[zypper-docker] apply updates"
-	author := os.Getenv("USER")
+	comment := ctx.String("message")
+	author := ctx.String("author")
 
 	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
+	toIgnore := []string{"author", "message"}
+
 	cmd := fmt.Sprintf(
 		"zypper ref && zypper -n %v",
-		cmdWithFlags("up", ctx, boolFlags))
+		cmdWithFlags("up", ctx, boolFlags, toIgnore))
 	err := runCommandAndCommitToImage(
 		img,
 		repo,


### PR DESCRIPTION
Make it possible to specify an author and a message for the new layer
created by the "patch" and "update" commands.

This fixes issue #26