### PR TITLE
Fix flags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -87,6 +87,10 @@ func newApp() *cli.App {
 					Name:  "no-recommends",
 					Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
 				},
+				cli.BoolFlag{
+					Name:  "replacefiles",
+					Usage: "Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error.",
+				},
 				cli.StringFlag{
 					Name:   "author",
 					EnvVar: "USERNAME",
@@ -150,12 +154,12 @@ func newApp() *cli.App {
 				cli.StringFlag{
 					Name:  "date",
 					Value: "",
-					Usage: "List patches issued up to, but not including, the specified date (YYYY-MM-DD).",
+					Usage: "Install patches issued up to, but not including, the specified date (YYYY-MM-DD).",
 				},
 				cli.StringFlag{
-					Name:  "issues",
+					Name:  "g, category",
 					Value: "",
-					Usage: "Look for issues whose number, summary, or description matches the specified string.",
+					Usage: "Install only patches with this category.",
 				},
 				cli.BoolFlag{
 					Name:  "l, auto-agree-with-licenses",
@@ -164,6 +168,10 @@ func newApp() *cli.App {
 				cli.BoolFlag{
 					Name:  "no-recommends",
 					Usage: "By default, zypper installs also packages recommended by the requested ones. This option causes the recommended packages to be ignored and only the required ones to be installed.",
+				},
+				cli.BoolFlag{
+					Name:  "replacefiles",
+					Usage: "Install the packages even if they replace files from other, already installed, packages. Default is to treat file conflicts as an error.",
 				},
 				cli.StringFlag{
 					Name:   "author",

--- a/flags.go
+++ b/flags.go
@@ -108,12 +108,12 @@ func newApp() *cli.App {
 				cli.StringFlag{
 					Name:  "b, bugzilla",
 					Value: "",
-					Usage: "List available needed patches for all Bugzilla issues, or issues whose number matches the given string.",
+					Usage: "List available needed patches for all Bugzilla issues, or issues whose number matches the given string (--bugzilla=#).",
 				},
 				cli.StringFlag{
 					Name:  "cve",
 					Value: "",
-					Usage: "List available needed patches for all CVE issues, or issues whose number matches the given string.",
+					Usage: "List available needed patches for all CVE issues, or issues whose number matches the given string (--cve=#).",
 				},
 				cli.StringFlag{
 					Name:  "date",
@@ -123,7 +123,7 @@ func newApp() *cli.App {
 				cli.StringFlag{
 					Name:  "issues",
 					Value: "",
-					Usage: "Look for issues whose number, summary, or description matches the specified string.",
+					Usage: "Look for issues whose number, summary, or description matches the specified string (--issue=string).",
 				},
 				cli.StringFlag{
 					Name:  "g, category",
@@ -140,12 +140,12 @@ func newApp() *cli.App {
 				cli.StringFlag{
 					Name:  "b, bugzilla",
 					Value: "",
-					Usage: "List available needed patches for all Bugzilla issues, or issues whose number matches the given string.",
+					Usage: "Install available needed patches for all Bugzilla issues, or issues whose number matches the given string (--bugzilla=#).",
 				},
 				cli.StringFlag{
 					Name:  "cve",
 					Value: "",
-					Usage: "List available needed patches for all CVE issues, or issues whose number matches the given string.",
+					Usage: "Install available needed patches for all CVE issues, or issues whose number matches the given string (--cve=#).",
 				},
 				cli.StringFlag{
 					Name:  "date",

--- a/patches.go
+++ b/patches.go
@@ -48,7 +48,8 @@ func patchCmd(ctx *cli.Context) {
 	comment := ctx.String("message")
 	author := ctx.String("author")
 
-	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
+	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends",
+		"replacefiles"}
 	toIgnore := []string{"author", "message"}
 
 	cmd := fmt.Sprintf(

--- a/test_helper.go
+++ b/test_helper.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"log"
 
 	"github.com/codegangsta/cli"
@@ -53,4 +54,20 @@ func testContext(args []string, force bool) *cli.Context {
 		log.Fatal("Cannot parse cli options", err)
 	}
 	return c
+}
+
+func compareStringSlices(actual, expected []string) error {
+	if len(actual) != len(expected) {
+		return fmt.Errorf("different size, actual is %d while expected is %d",
+			len(actual), len(expected))
+	}
+
+	for pos, item := range actual {
+		if item != expected[pos] {
+			return fmt.Errorf("item at position %d are different, expected %s, got %s",
+				pos, expected[pos], item)
+		}
+	}
+
+	return nil
 }

--- a/updates.go
+++ b/updates.go
@@ -44,7 +44,8 @@ func updateCmd(ctx *cli.Context) {
 	comment := ctx.String("message")
 	author := ctx.String("author")
 
-	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
+	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends",
+		"replacefiles"}
 	toIgnore := []string{"author", "message"}
 
 	cmd := fmt.Sprintf(

--- a/zypper-docker.go
+++ b/zypper-docker.go
@@ -37,6 +37,7 @@ func main() {
 	// documentation of this function for more information.
 	_ = getDockerClient()
 
+	os.Args = fixArgsForZypper(os.Args)
 	app := newApp()
 	app.RunAndExitOnError()
 }


### PR DESCRIPTION
Make sure all zypper flags are mapped to zypper-docker.

Ensure zypper-docker behaves like zypper itself when dealing with special flags like `bugzilla`.

zypper has some special flags that can act both as boolean and string ones. For example:
```
zypper lp --bugzilla
```
In the above case --buzilla acts as a boolean flag, while with:
```
zypper lp --bugzilla=123
```
acts like a string flag.

We have to differentiate between invocations with and without the "=".
When the "=" is not found we have to artificially inject an empty string to avoid the next parameter to be considered the flag value.

**NOTE WELL:** this PR is based on code of https://github.com/SUSE/zypper-docker/pull/29, which is not yet merged into master. I'll rebase this PR once the code is in master.

