### PR TITLE
Ensure zypper's special flags are treated properly

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -21,6 +21,12 @@ import (
 	"github.com/codegangsta/cli"
 )
 
+var specialFlags = []string{
+	"-b", "--bugzilla",
+	"--cve",
+	"--issues",
+}
+
 // It appends the set flags with the given command.
 // `boolFlags` is a list of strings containing the names of the boolean
 // command line options. These have to be handled in a slightly different
@@ -56,10 +62,15 @@ func cmdWithFlags(cmd string, ctx *cli.Context, boolFlags, toIgnore []string) st
 			if arrayInclude(boolFlags, name) {
 				cmd += fmt.Sprintf(" %v%s", dash, name)
 			} else {
-				cmd += fmt.Sprintf(" %v%s %s", dash, name, value)
+				if arrayInclude(specialFlags, fmt.Sprintf("%v%s", dash, name)) && value != "" {
+					cmd += fmt.Sprintf(" %v%s=%s", dash, name, value)
+				} else {
+					cmd += fmt.Sprintf(" %v%s %s", dash, name, value)
+				}
 			}
 		}
 	}
+
 	return cmd
 }
 
@@ -74,11 +85,6 @@ func cmdWithFlags(cmd string, ctx *cli.Context, boolFlags, toIgnore []string) st
 // When the "=" is not found we have to artificially inject an empty string
 // to avoid the next parameter to be considered the flag value.
 func fixArgsForZypper(args []string) []string {
-	specialFlags := []string{
-		"-b", "--bugzilla",
-		"--cve",
-		"--issues",
-	}
 	sanitizedArgs := []string{}
 	skip := false
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -82,9 +82,9 @@ func TestCmdWithFlags(t *testing.T) {
 				Usage: "List available needed patches for all CVE issues, or issues whose number matches the given string.",
 			},
 			cli.StringFlag{
-				Name:  "date",
+				Name:  "issues",
 				Value: "",
-				Usage: "Install patches issued up to, but not including, the specified date (YYYY-MM-DD).",
+				Usage: "doc",
 			},
 			cli.StringFlag{
 				Name:  "to-ignore",
@@ -110,14 +110,14 @@ func TestCmdWithFlags(t *testing.T) {
 	set.String("b", "bugzilla_value", "doc")
 	set.String("cve", "cve_value", "doc")
 	set.String("to-ignore", "to_ignore_value", "doc")
-	set.String("date", "", "doc")
+	set.String("issues", "", "doc")
 	set.Bool("l", true, "doc")
 	set.Bool("no-recommends", true, "doc")
 	err := set.Parse([]string{
 		"-b", "bugzilla_value",
 		"--cve", "cve_value",
 		"--to-ignore", "to_ignore_value",
-		"--date", "",
+		"--issues", "",
 		"-l",
 		"--no-recommends",
 	})
@@ -131,7 +131,7 @@ func TestCmdWithFlags(t *testing.T) {
 	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
 	toIgnore := []string{"to-ignore"}
 	actual := cmdWithFlags("cmd", ctx, boolFlags, toIgnore)
-	expected := "cmd -b bugzilla_value --cve cve_value --date  -l --no-recommends"
+	expected := "cmd -b=bugzilla_value --cve=cve_value --issues  -l --no-recommends"
 
 	if expected != actual {
 		t.Fatal("Wrong command")


### PR DESCRIPTION
We forgot to add the `=` symbol where needed.