### PR TITLE
Drop the '-b' bugzilla flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -110,7 +110,7 @@ func newApp() *cli.App {
 			Action:  listPatchesCmd,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "b, bugzilla",
+					Name:  "bugzilla",
 					Value: "",
 					Usage: "List available needed patches for all Bugzilla issues, or issues whose number matches the given string (--bugzilla=#).",
 				},
@@ -142,7 +142,7 @@ func newApp() *cli.App {
 			Action: patchCmd,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "b, bugzilla",
+					Name:  "bugzilla",
 					Value: "",
 					Usage: "Install available needed patches for all Bugzilla issues, or issues whose number matches the given string (--bugzilla=#).",
 				},

--- a/helpers.go
+++ b/helpers.go
@@ -22,7 +22,7 @@ import (
 )
 
 var specialFlags = []string{
-	"-b", "--bugzilla",
+	"--bugzilla",
 	"--cve",
 	"--issues",
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -72,7 +72,7 @@ func TestCmdWithFlags(t *testing.T) {
 		Usage: "List all the images based on either OpenSUSE or SLES",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "b, bugzilla",
+				Name:  "bugzilla",
 				Value: "",
 				Usage: "List available needed patches for all Bugzilla issues, or issues whose number matches the given string.",
 			},
@@ -107,14 +107,14 @@ func TestCmdWithFlags(t *testing.T) {
 	}
 
 	set := flag.NewFlagSet("test", 0)
-	set.String("b", "bugzilla_value", "doc")
+	set.String("bugzilla", "bugzilla_value", "doc")
 	set.String("cve", "cve_value", "doc")
 	set.String("to-ignore", "to_ignore_value", "doc")
 	set.String("issues", "", "doc")
 	set.Bool("l", true, "doc")
 	set.Bool("no-recommends", true, "doc")
 	err := set.Parse([]string{
-		"-b", "bugzilla_value",
+		"--bugzilla", "bugzilla_value",
 		"--cve", "cve_value",
 		"--to-ignore", "to_ignore_value",
 		"--issues", "",
@@ -131,7 +131,7 @@ func TestCmdWithFlags(t *testing.T) {
 	boolFlags := []string{"l", "auto-agree-with-licenses", "no-recommends"}
 	toIgnore := []string{"to-ignore"}
 	actual := cmdWithFlags("cmd", ctx, boolFlags, toIgnore)
-	expected := "cmd -b=bugzilla_value --cve=cve_value --issues  -l --no-recommends"
+	expected := "cmd --bugzilla=bugzilla_value --cve=cve_value --issues  -l --no-recommends"
 
 	if expected != actual {
 		t.Fatal("Wrong command")


### PR DESCRIPTION
zypper handles `-b` and `--bugzilla` in a different way:
  * `zypper lp -b` is equivalent to `zypper lp --bugzilla`
  * `zypper lp -b=123` is not accepted, while `zypper lp --bugzilla=123` is valid

To avoid confusion we decided to drop the short form of the bugzilla flag.