### PR TITLE
zypper-docker: make proper usage of container cmd

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,7 +125,7 @@ func runStreamedCommand(img, cmd string, getError bool) error {
 	}
 
 	cmd = fmt.Sprintf("zypper ref && zypper %v", cmd)
-	id, err := runCommandInContainer(img, []string{"/bin/sh", "-c", cmd}, true)
+	id, err := runCommandInContainer(img, []string{cmd}, true)
 	removeContainer(id)
 
 	if getError {
@@ -246,7 +246,8 @@ func createContainer(img string, cmd []string) (string, error) {
 	// First of all we create a container in which we will run the command.
 	config := &dockerclient.ContainerConfig{
 		Image:        img,
-		Entrypoint:   cmd,
+		Cmd:          cmd,
+		Entrypoint:   []string{"/bin/sh", "-c"},
 		AttachStdout: true,
 		AttachStderr: true,
 		// required to avoid garbage when cmd overwrites the terminal
@@ -284,7 +285,7 @@ func commitContainerToImage(containerId, repo, tag, comment, author string) erro
 // The container is always deleted.
 // If something goes wrong an error message is returned.
 func runCommandAndCommitToImage(img, target_repo, target_tag, cmd, comment, author string) error {
-	containerId, err := runCommandInContainer(img, []string{"/bin/sh", "-c", cmd}, true)
+	containerId, err := runCommandInContainer(img, []string{cmd}, true)
 	if err != nil {
 		return err
 	}

--- a/mock_test.go
+++ b/mock_test.go
@@ -91,7 +91,7 @@ func (mc *mockClient) CreateContainer(config *dockerclient.ContainerConfig, name
 		return "", errors.New("Create failed")
 	}
 	name = fmt.Sprintf("zypper-docker-private-%s", config.Image)
-	mc.lastCmd = config.Entrypoint
+	mc.lastCmd = config.Cmd
 
 	return name, nil
 }

--- a/patches_test.go
+++ b/patches_test.go
@@ -45,13 +45,12 @@ func testPatchContext(source, destination string) *cli.Context {
 
 func testCommand() string {
 	cmd := dockerClient.(*mockClient).lastCmd
-	if len(cmd) != 3 {
+	if len(cmd) != 1 {
 		return ""
 	}
 
-	// [0]: "/bin/sh", [1]: "-c", [2]: the actual command.
 	// The command is basically: "zypper ref && actual command".
-	return strings.TrimSpace(strings.Split(cmd[2], "&&")[1])
+	return strings.TrimSpace(strings.Split(cmd[0], "&&")[1])
 }
 
 func TestListPatchesNoImageSpecified(t *testing.T) {


### PR DESCRIPTION
The right approach to deal with images using a custom entrypoint is to
set the entrypoint back to `/bin/sh -c` (like docker does by default
when there's no entrypoint defined) and then put our command as `cmd`.

By doing that the images generated by `patch` and `update` behave in
the proper way when inspected via `docker history`: the `created by`
column contains the right information.