### PR TITLE
patch_check: use the same exit code as zypper

### DIFF
--- a/patch_check.go
+++ b/patch_check.go
@@ -53,6 +53,7 @@ func patchCheck(image string, ctx *cli.Context) {
 		// then we do nothing.
 		de := err.(dockerError)
 		if de.ExitCode == 100 || de.ExitCode == 101 {
+			exitWithCode(de.ExitCode)
 			return
 		}
 	}

--- a/patch_check_test.go
+++ b/patch_check_test.go
@@ -82,6 +82,12 @@ func TestPatchCheckSupportedNonZeroExit(t *testing.T) {
 	if len(strings.Split(buffer.String(), "\n")) != 2 {
 		t.Fatalf("Something went wrong")
 	}
+	if exitInvocations != 1 {
+		t.Fatalf("Expected to have exited with error")
+	}
+	if lastCode != 100 {
+		t.Fatalf("Expected exit code: 100, got %v", lastCode)
+	}
 }
 
 func TestPatchCheckOk(t *testing.T) {

--- a/test_helper.go
+++ b/test_helper.go
@@ -29,11 +29,9 @@ func setupTestExitStatus() {
 	exitInvocations = 0
 	lastCode = 0
 
-	if exitWithCode == nil {
-		exitWithCode = func(code int) {
-			lastCode = code
-			exitInvocations += 1
-		}
+	exitWithCode = func(code int) {
+		lastCode = code
+		exitInvocations += 1
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>