### PR TITLE
Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-zypper-docker
+.bundle
+Gemfile.lock
+.ruby-version
+spec/reports
 .vagrant
+zypper-docker

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'cheetah'
+gem 'ci_reporter_rspec'
+gem 'rake'
+gem 'rspec'

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,23 @@ test_tip ::
 
 test :: test_14 test_15 test_tip
 
+test_integration :: build_zypper_docker build_integration_tests
+	docker run \
+		--rm \
+		--volume="/var/run/docker.sock:/var/run/docker.sock" \
+		--volume="$(CURDIR):/code" \
+		zypper-docker-integration-tests \
+		rake test
+
 clean ::
 	docker rmi zypper-docker-testing-1.4
 	docker rmi zypper-docker-testing-1.5
 	docker rmi zypper-docker-testing-tip
+	docker rmi zypper-docker-integration-tests
+	rm -f zypper-docker
+
+build_zypper_docker :: build_tip
+	docker run --rm -v `pwd`:/go/src/github.com/SUSE/zypper-docker zypper-docker-testing-tip godep go build
 
 build_14 ::
 	@echo Building zypper-docker-testing-1.4
@@ -34,5 +47,9 @@ build_15 ::
 build_tip ::
 	@echo Building zypper-docker-testing-tip
 	docker build -f docker/Dockerfile-tip -t zypper-docker-testing-tip docker
+
+build_integration_tests ::
+	@echo Building zypper-docker-integration-tests
+	docker build -f docker/Dockerfile-integration-tests -t zypper-docker-integration-tests $(CURDIR)
 
 build :: build_14 build_15 build_tip

--- a/README.md
+++ b/README.md
@@ -245,6 +245,37 @@ type:
 $ make test
 ```
 
+## Testing
+
+This project is covered both by unit and integration tests.
+
+### Unit tests
+
+Unit tests are written in Go and can be invoked by doing:
+
+```
+make test
+```
+
+This will build `zypper-docker` using different Go versions and trigger the unit tests.
+
+### Integration tests
+
+The integration tests invoke the `zypper-docker` binary and test different scenarios.
+
+They are written using RSpec and are located under `/spec`.
+
+The integration tests can be started by doing:
+
+```
+make test_integration
+```
+
+This will build a Docker image containing all the software (RSpec, plus other
+Ruby gems) required to run the tests.
+The image will be started, the socket used by the Docker daemon on the host will
+be mounted inside of the new container. That makes possible to invoke the docker
+client from within the container itself.
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require "rspec/core/rake_task"
+require "ci/reporter/rake/rspec"
+
+desc "Run the integration tests"
+RSpec::Core::RakeTask.new("spec")
+
+desc "Run tests and generate JUnit compatible files"
+task test: ["ci:setup:rspec", "spec"]

--- a/docker/Dockerfile-integration-tests
+++ b/docker/Dockerfile-integration-tests
@@ -1,0 +1,18 @@
+FROM opensuse:tumbleweed
+MAINTAINER Flavio Castelli <fcastelli@suse.com>
+
+RUN zypper -n in --no-recommends \
+  docker \
+  ruby \
+  ruby-devel
+# libffi-devel-gcc5 \
+# make \
+# gcc
+
+WORKDIR /code
+
+COPY Gemfile /code/Gemfile
+RUN gem install bundle
+RUN bundler.ruby2.2 install --retry=3
+
+ENV PATH=/code:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/docker/Dockerfile-vulnerable-image
+++ b/docker/Dockerfile-vulnerable-image
@@ -1,0 +1,15 @@
+# This Dockerfile produces the "opensuse-old-alsa" image that is being used in
+# some tests.
+
+FROM opensuse:13.2
+MAINTAINER Miquel Sabaté Solà <msabate@suse.com>
+
+RUN zypper --non-interactive --gpg-auto-import-keys ref
+
+# This image has to be out-dated so tests can work on it. That's why we are
+# installing an old version of a package that we know that has received
+# updates.
+RUN zypper in -y --repo OSS alsa-utils
+
+# No entry point, no workdir, no nothing; this is just an image used for
+# testing purposes.

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,0 +1,63 @@
+require "cheetah"
+require "pathname"
+
+class Settings
+  VULNERABLE_IMAGE_REPO = "zypper-docker-tests-vulnerable-image"
+  VULNERABLE_IMAGE_TAG = "0.1"
+  VULNERABLE_IMAGE = "#{VULNERABLE_IMAGE_REPO}:#{VULNERABLE_IMAGE_TAG}"
+
+end
+
+module SpecHelper
+  def docker_image_exists?(repo, tag)
+    if tag == "" || tag.nil?
+      tag = "latest"
+    end
+    output = Cheetah.run("docker", "images", repo, stdout: :capture)
+    output.include?(tag)
+  end
+
+  def pull_image(image)
+    system("docker pull #{image}")
+  end
+
+  def ensure_vulnerable_image_exists
+    return if docker_image_exists?(Settings::VULNERABLE_IMAGE_REPO, Settings::VULNERABLE_IMAGE_TAG)
+
+    # Do not use cheetah, we want live streaming of what is happening
+    puts "Building #{Settings::VULNERABLE_IMAGE}"
+    cmd = "docker build" \
+      " -f #{File.join(Pathname.new(__FILE__).parent.parent, "docker/Dockerfile-vulnerable-image")}" \
+      " -t #{Settings::VULNERABLE_IMAGE}" \
+      " #{Pathname.new(__FILE__).parent.parent}"
+    puts cmd
+    system(cmd)
+    exit(1) if $? != 0
+  end
+
+  def remove_docker_image(image)
+    Cheetah.run("docker", "rmi", image)
+  end
+
+  def docker_image_commit_details(image)
+    author = Cheetah.run("docker", "inspect", "--format='{{.Author}}'",  image, stdout: :capture)
+    message = Cheetah.run("docker", "inspect", "--format='{{.Comment}}'", image, stdout: :capture)
+
+    return author, message
+  end
+
+  def check_commit_details(expected_author, expected_message, image)
+    actual_author, actual_message = docker_image_commit_details(image)
+    expect(expected_author.chomp).to eq(actual_author.chomp)
+    expect(expected_message.chomp).to eq(actual_message.chomp)
+  end
+
+end
+
+RSpec.configure do |config|
+  config.include(SpecHelper)
+
+  config.before :all do
+    ensure_vulnerable_image_exists
+  end
+end

--- a/spec/patches_operations_spec.rb
+++ b/spec/patches_operations_spec.rb
@@ -1,0 +1,194 @@
+require_relative "helper"
+
+describe "patch operations" do
+  let(:author) { "zypper-docker test suite" }
+  let(:message) { "this is a test" }
+
+  before :all do
+    @patched_image_repo = "zypper-docker-patched-image"
+    @patched_image_tag  = "1.0"
+    @patched_image      = "#{@patched_image_repo}:#{@patched_image_tag}"
+  end
+
+  after :all do
+    if docker_image_exists?(@patched_image_repo, @patched_image_tag)
+      remove_docker_image(@patched_image)
+    end
+  end
+
+  context 'listing patches' do
+    it 'show patch name' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include("openSUSE-2015-345")
+      expect(output).to include("openSUSE-2015-526")
+    end
+
+    it 'can show the bugzilla number' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--bugzilla", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include("928394")
+      expect(output).to include("940950")
+    end
+
+    it 'can filter by bugzilla number' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--bugzilla=928394", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include("928394")
+      expect(output).not_to include("940950")
+    end
+
+    it 'can show the cve number' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--cve", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include('CVE-2015-1545')
+      expect(output).to include('CVE-2015-1546')
+    end
+
+    it 'can filter by cve number' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--cve=CVE-2015-1545", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).not_to include('CVE-2015-1546')
+      expect(output).to include('CVE-2015-1545')
+    end
+
+    it 'can filter by date' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--date", "2014-12-1", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include('No updates found')
+
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--date", "2015-12-1", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include('openSUSE-2015-345')
+    end
+
+    it 'can show the issue type' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--issues", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include('bugzilla')
+      expect(output).to include('cve')
+    end
+
+    it 'can filter by issue type' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--issues=cve", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).not_to include('bugzilla')
+      expect(output).to include('cve')
+    end
+
+    it 'filter by category name' do
+      output = Cheetah.run(
+        "zypper-docker", "lp", "--category", "recommended", Settings::VULNERABLE_IMAGE,
+        stdout: :capture)
+      expect(output).to include('openSUSE-2015-345')
+    end
+
+    context 'apply patches' do
+      before(:each) do
+        if docker_image_exists?(@patched_image_repo, @patched_image_tag)
+          remove_docker_image(@patched_image)
+        end
+      end
+
+      it 'can apply by bugzilla number' do
+        Cheetah.run(
+          "zypper-docker", "patch",
+          "--author", author,
+          "--message", message,
+          "--bugzilla=928394",
+          Settings::VULNERABLE_IMAGE,
+          @patched_image)
+        expect(docker_image_exists?(@patched_image_repo, @patched_image_tag)).to be true
+
+        output = Cheetah.run(
+          "zypper-docker", "lp", "--bugzilla=928394", @patched_image,
+          stdout: :capture)
+        expect(output).not_to include('928394')
+
+        check_commit_details(author, message, @patched_image)
+      end
+
+      it 'can apply by cve number' do
+        Cheetah.run(
+          "zypper-docker", "patch",
+          "--author", author,
+          "--message", message,
+          "--cve=CVE-2015-1545",
+          Settings::VULNERABLE_IMAGE,
+          @patched_image)
+        expect(docker_image_exists?(@patched_image_repo, @patched_image_tag)).to be true
+
+        output = Cheetah.run(
+          "zypper-docker", "lp", "--cve=CVE-2015-1545", @patched_image,
+          stdout: :capture)
+        expect(output).not_to include('CVE-2015-1545')
+
+        check_commit_details(author, message, @patched_image)
+      end
+
+      it 'can apply by date' do
+        Cheetah.run(
+          "zypper-docker", "patch",
+          "--author", author,
+          "--message", message,
+          "--date", "2015-8-1",
+          Settings::VULNERABLE_IMAGE,
+          @patched_image)
+        expect(docker_image_exists?(@patched_image_repo, @patched_image_tag)).to be true
+
+        output = Cheetah.run(
+          "zypper-docker", "lp", "--date", "2015-8-1", @patched_image,
+          stdout: :capture)
+        expect(output).not_to include('openSUSE-2015-345')
+        expect(output).not_to include('openSUSE-2015-497')
+        expect(output).not_to include('openSUSE-2015-526')
+
+        check_commit_details(author, message, @patched_image)
+      end
+
+      it 'apply by category name' do
+        Cheetah.run(
+          "zypper-docker", "patch",
+          "--author", author,
+          "--message", message,
+          "--category", "recommended",
+          Settings::VULNERABLE_IMAGE,
+          @patched_image)
+        expect(docker_image_exists?(@patched_image_repo, @patched_image_tag)).to be true
+
+        output = Cheetah.run(
+          "zypper-docker", "lp", @patched_image,
+          stdout: :capture)
+        expect(output).not_to include('recommended')
+        expect(output).to include('security')
+
+        check_commit_details(author, message, @patched_image)
+      end
+    end
+
+    it 'checks patches' do
+      exception = nil
+
+      begin
+        Cheetah.run(
+          "zypper-docker", "pchk", Settings::VULNERABLE_IMAGE)
+      rescue Cheetah::ExecutionFailed => e
+        exception = e
+      end
+      expect(exception).not_to be_nil
+      expect(exception.status.exitstatus).to eq(101)
+      expect(exception.stdout).to include('security patches')
+      expect(exception.stdout).to include('patches needed')
+    end
+
+  end
+end

--- a/spec/ps_spec.rb
+++ b/spec/ps_spec.rb
@@ -1,0 +1,68 @@
+require_relative "helper"
+
+describe "ps operations" do
+  let(:author) { "zypper-docker test suite" }
+  let(:message) { "this is a test" }
+
+  before :all do
+    @keep_alpine = docker_image_exists?("alpine", "latest")
+    if !@keep_alpine
+      pull_image("alpine:latest")
+    end
+    @patched_image_repo = "zypper-docker-patched-image"
+    @patched_image_tag  = "1.0"
+    @patched_image      = "#{@patched_image_repo}:#{@patched_image_tag}"
+
+    @vul_container = "vulnerable_container"
+    @not_suse_container = "not_suse_container"
+
+    Cheetah.run(
+      "docker", "run",
+      "-d",
+      "--name", @vul_container,
+      Settings::VULNERABLE_IMAGE,
+      "sleep", "1h")
+    Cheetah.run(
+      "docker", "run",
+      "-d",
+      "--name", @not_suse_container,
+      "alpine:latest",
+      "sleep", "1h")
+  end
+
+  after :all do
+    kill_and_remove_container(@vul_container)
+    kill_and_remove_container(@not_suse_container)
+
+    remove_docker_image("alpine:latest") unless @keep_alpine
+    if docker_image_exists?(@patched_image_repo, @patched_image_tag)
+      remove_docker_image(@patched_image)
+    end
+  end
+
+  it "handle uknown containers" do
+    output = Cheetah.run("zypper-docker", "ps", stdout: :capture)
+    expect(output).to include("The following containers have an unknown state")
+    expect(output).to include(Settings::VULNERABLE_IMAGE)
+    expect(output).to include("alpine:latest")
+  end
+
+  it "recognizes vulnerable containers" do
+    Cheetah.run(
+      "zypper-docker", "patch",
+      "--author", author,
+      "--message", message,
+      Settings::VULNERABLE_IMAGE,
+      @patched_image)
+
+    output = Cheetah.run("zypper-docker", "ps", stdout: :capture).split("\n")
+    expect(output[0]).to include("Running containers whose images have been updated")
+    expect(output[1]).to include(Settings::VULNERABLE_IMAGE)
+  end
+
+  def kill_and_remove_container(container)
+    Cheetah.run("docker", "kill", container)
+    Cheetah.run("docker", "rm", container)
+  end
+
+end

--- a/spec/update_operations_spec.rb
+++ b/spec/update_operations_spec.rb
@@ -1,0 +1,52 @@
+require_relative "helper"
+
+describe "update operations" do
+  let(:author) { "zypper-docker test suite" }
+  let(:message) { "this is a test" }
+
+  before :all do
+    @patched_image_repo = "zypper-docker-patched-image"
+    @patched_image_tag  = "1.0"
+    @patched_image      = "#{@patched_image_repo}:#{@patched_image_tag}"
+  end
+
+  after :all do
+    if docker_image_exists?(@patched_image_repo, @patched_image_tag)
+      remove_docker_image(@patched_image)
+    end
+  end
+
+  it "lists updates" do
+    output = Cheetah.run("zypper-docker", "lu", Settings::VULNERABLE_IMAGE, stdout: :capture)
+    expect(output).to include("alsa-utils")
+  end
+
+  it "applies updates" do
+    Cheetah.run(
+      "zypper-docker", "up",
+      "--author", author,
+      "--message", message,
+      Settings::VULNERABLE_IMAGE,
+      @patched_image)
+
+    expect(docker_image_exists?(@patched_image_repo, @patched_image_tag)).to be true
+    output = Cheetah.run("zypper-docker", "lu", @patched_image, stdout: :capture)
+    expect(output).not_to include("alsa-utils")
+
+    check_commit_details(author, message, @patched_image)
+  end
+
+  it "refuses to overwrite an existing image while doing an update" do
+    expect(docker_image_exists?(@patched_image_repo, @patched_image_tag)).to be true
+
+    expect {
+      Cheetah.run(
+        "zypper-docker", "up",
+        "--author", author,
+        "--message", message,
+        Settings::VULNERABLE_IMAGE,
+      @patched_image)
+    }.to raise_error(Cheetah::ExecutionFailed)
+  end
+
+end


### PR DESCRIPTION
This makes possible to run the integration tests previously defined inside of our internal CI infrastructure.