### PR TITLE
Improved how logging is done

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -156,7 +156,8 @@ func getCacheFile() *cachedData {
 	err := dec.Decode(&cd)
 	_ = file.Close()
 	if err != nil {
-		log.Println("Cache file has a bad format!")
+		log.Printf("Decoding of cache file failed: %v\n", err)
+		// TODO: (mssola) shouldn't this be invalid ?
 		return &cachedData{Valid: true, Path: file.Name()}
 	}
 	return cd

--- a/cache_test.go
+++ b/cache_test.go
@@ -108,7 +108,7 @@ func TestCacheBadJson(t *testing.T) {
 	if !file.Valid {
 		t.Fatal("It should be valid")
 	}
-	if !strings.Contains(buffer.String(), "Cache file has a bad format!") {
+	if !strings.Contains(buffer.String(), "Decoding of cache file failed") {
 		t.Fatal("Wrong log")
 	}
 }

--- a/flags.go
+++ b/flags.go
@@ -58,6 +58,8 @@ func newApp() *cli.App {
 		cli.ShowAppHelp(context)
 	}
 
+	app.Before = setupLogger
+
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
 			Name:  "n, non-interactive",
@@ -75,30 +77,50 @@ func newApp() *cli.App {
 			Name:  "f, force",
 			Usage: "Ignore all the local caches",
 		},
+		cli.BoolFlag{
+			Name:  "d, debug",
+			Usage: "Show all the logged messages on stdout",
+		},
 	}
 	app.Commands = []cli.Command{
 		{
-			Name:   "images",
-			Usage:  "List all the images based on either OpenSUSE or SLES",
+			Name:  "images",
+			Usage: "List all the images based on either OpenSUSE or SLES",
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[images] ")
+				return nil
+			},
 			Action: imagesCmd,
 		},
 		{
 			Name:    "list-updates",
 			Aliases: []string{"lu"},
 			Usage:   "List all the available updates",
-			Action:  listUpdatesCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[list-updates] ")
+				return nil
+			},
+			Action: listUpdatesCmd,
 		},
 		{
 			Name:    "list-updates-container",
 			Aliases: []string{"luc"},
 			Usage:   "List all the available updates for the given container",
-			Action:  listUpdatesContainerCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[list-updates-container] ")
+				return nil
+			},
+			Action: listUpdatesContainerCmd,
 		},
 		{
 			Name:    "update",
 			Aliases: []string{"up"},
 			Usage:   "Install the available updates",
 			Action:  updateCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[update] ")
+				return nil
+			},
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "l, auto-agree-with-licenses",
@@ -129,6 +151,10 @@ func newApp() *cli.App {
 			Aliases: []string{"lp"},
 			Usage:   "List all the available patches",
 			Action:  listPatchesCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[list-patches] ")
+				return nil
+			},
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "bugzilla",
@@ -162,6 +188,10 @@ func newApp() *cli.App {
 			Aliases: []string{"lpc"},
 			Usage:   "List all the available patches for the given container",
 			Action:  listPatchesContainerCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[list-patches-container] ")
+				return nil
+			},
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "b, bugzilla",
@@ -194,6 +224,10 @@ func newApp() *cli.App {
 			Name:   "patch",
 			Usage:  "Install the available patches",
 			Action: patchCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[patch] ")
+				return nil
+			},
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "bugzilla",
@@ -243,17 +277,29 @@ func newApp() *cli.App {
 			Name:    "patch-check",
 			Aliases: []string{"pchk"},
 			Usage:   "Check for patches",
-			Action:  patchCheckCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[patch-check] ")
+				return nil
+			},
+			Action: patchCheckCmd,
 		},
 		{
 			Name:    "patch-check-container",
 			Aliases: []string{"pchkc"},
 			Usage:   "Check for patches available for the given container",
-			Action:  patchCheckContainerCmd,
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[patch-check-container] ")
+				return nil
+			},
+			Action: patchCheckContainerCmd,
 		},
 		{
-			Name:   "ps",
-			Usage:  "List all the containers that are outdated",
+			Name:  "ps",
+			Usage: "List all the containers that are outdated",
+			Before: func(ctx *cli.Context) error {
+				log.SetPrefix("[ps] ")
+				return nil
+			},
 			Action: psCmd,
 		},
 	}

--- a/flags_test.go
+++ b/flags_test.go
@@ -25,7 +25,7 @@ func TestVersion(t *testing.T) {
 func TestNewApp(t *testing.T) {
 	app := newApp()
 
-	if len(app.Flags) != 4 {
+	if len(app.Flags) != 5 {
 		t.Fatal("Wrong number of global flags")
 	}
 	if len(app.Commands) != 10 {

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/codegangsta/cli"
+)
+
+// logFileName stores the name of the log file when logging is not done through
+// the standard output.
+const logFileName = ".zypper-docker.log"
+
+// setupLogger picks the proper output file for this application.
+func setupLogger(ctx *cli.Context) error {
+	// If the debug flag is set, just print the log to stdout.
+	if ctx.GlobalBool("debug") {
+		log.SetOutput(os.Stdout)
+		return nil
+	}
+
+	// Try to set the log inside of the HOME directory. If this is not
+	// possible, just use stdout.
+	path := filepath.Join(os.Getenv("HOME"), logFileName)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		log.SetOutput(os.Stdout)
+		log.Printf("Could not open log file: %v\n", err)
+	} else {
+		log.SetOutput(file)
+	}
+	return nil
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2015 SUSE LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/codegangsta/cli"
+	"github.com/mssola/capture"
+)
+
+func TestSetupLoggerDebug(t *testing.T) {
+	// Set debug mode.
+	set := flag.NewFlagSet("test", 0)
+	set.Bool("debug", true, "doc")
+	c := cli.NewContext(nil, set, nil)
+
+	res := capture.All(func() {
+		_ = setupLogger(c)
+		log.Printf("Test")
+	})
+	if !strings.HasSuffix(string(res.Stdout), "Test\n") {
+		t.Fatalf("'%v' expected to have logged 'Test'\n", string(res.Stdout))
+	}
+}
+
+func TestSetupLoggerHome(t *testing.T) {
+	abs, err := filepath.Abs("test")
+	if err != nil {
+		t.Fatalf("Could not setup the test suite: %v\n", err)
+	}
+	home := os.Getenv("HOME")
+	defer func() {
+		_ = os.Setenv("HOME", home)
+		_ = os.Remove(filepath.Join(abs, logFileName))
+	}()
+	_ = os.Setenv("HOME", abs)
+
+	res := capture.All(func() {
+		_ = setupLogger(testContext([]string{}, false))
+		log.Printf("Test")
+	})
+	if len(res.Stdout) != 0 {
+		t.Fatal("Nothing should've been printed to stdout\n")
+	}
+	contents, err := ioutil.ReadFile(filepath.Join(abs, logFileName))
+	if err != nil {
+		t.Fatalf("Could not read contents of the log: %v\n", err)
+	}
+	if !strings.HasSuffix(string(contents), "Test\n") {
+		t.Fatalf("'%v' expected to have logged 'Test'\n", string(contents))
+	}
+}
+
+func TestSetupLoggerWrongHome(t *testing.T) {
+	home := os.Getenv("HOME")
+	defer func() {
+		_ = os.Setenv("HOME", home)
+	}()
+	abs, err := filepath.Abs("does_not_exist")
+	if err != nil {
+		t.Fatalf("Could not setup the test suite: %v\n", err)
+	}
+	_ = os.Setenv("HOME", abs)
+
+	res := capture.All(func() {
+		_ = setupLogger(testContext([]string{}, false))
+		log.Printf("Test")
+	})
+	if strings.Index(string(res.Stdout), "Could not open log file") == -1 {
+		t.Fatalf("An error should've been printed\n")
+	}
+	if strings.Index(string(res.Stdout), "Test") == -1 {
+		t.Fatalf("There should be a 'Test' string\n")
+	}
+}

--- a/patch_check.go
+++ b/patch_check.go
@@ -37,7 +37,8 @@ func patchCheckContainerCmd(ctx *cli.Context) {
 	patchCheck(container.Image, ctx)
 }
 
-// zypper-docker patch-check [flags] <image>
+// patchCheck calls the `zypper pchk` command for the given image and the given
+// arguments.
 func patchCheck(image string, ctx *cli.Context) {
 	err := runStreamedCommand(image, "pchk", true)
 	if err == nil {
@@ -57,6 +58,6 @@ func patchCheck(image string, ctx *cli.Context) {
 			return
 		}
 	}
-	log.Printf("Error: %v\n", err)
+	humanizeCommandError("zypper pchk", image, err)
 	exitWithCode(1)
 }

--- a/patch_check_test.go
+++ b/patch_check_test.go
@@ -58,7 +58,7 @@ func TestPatchCheckInvalidError(t *testing.T) {
 	if testCommand() != "zypper pchk" {
 		t.Fatalf("Wrong command!")
 	}
-	if !strings.Contains(buffer.String(), "Error: Command exited with status 2") {
+	if !strings.Contains(buffer.String(), "Could not execute command 'zypper pchk' successfully in image 'opensuse:13.2': Command exited with status 2.") {
 		t.Fatalf("Wrong error message")
 	}
 	if exitInvocations != 1 {

--- a/patches.go
+++ b/patches.go
@@ -40,7 +40,8 @@ func listPatchesCmd(ctx *cli.Context) {
 	listPatches(ctx.Args().First(), ctx)
 }
 
-// zypper-docker list-patches [flags] <image>
+// listParches calls the `zypper lp` command for the given image and the given
+// arguments.
 func listPatches(image string, ctx *cli.Context) {
 	// It's safe to ignore the returned error because we set to false the
 	// `getError` parameter of this function.

--- a/ps.go
+++ b/ps.go
@@ -27,7 +27,7 @@ func psCmd(ctx *cli.Context) {
 	client := getDockerClient()
 	containers, err := client.ListContainers(false, false, "")
 	if err != nil {
-		log.Println("Cannot list running containers", err)
+		log.Printf("Cannot list running containers: %v\n", err)
 		exitWithCode(1)
 		return
 	}

--- a/signals.go
+++ b/signals.go
@@ -34,10 +34,10 @@ func listenSignals() {
 			switch sig {
 			case syscall.SIGQUIT, syscall.SIGINT, syscall.SIGTSTP,
 				syscall.SIGTERM:
-				log.Printf("Shutting down gracefully.")
+				log.Printf("Signal '%v' received: shutting down gracefully.", sig)
 				killChannel <- true
 			default:
-				log.Printf("Signal not handled. Doing nothing...")
+				log.Printf("Signal '%v' not handled. Doing nothing...", sig)
 			}
 		}
 	}()

--- a/updates.go
+++ b/updates.go
@@ -21,10 +21,12 @@ import (
 	"github.com/codegangsta/cli"
 )
 
+// zypper-docker list-updates [flags] <image>
 func listUpdatesCmd(ctx *cli.Context) {
 	listUpdates(ctx.Args().First(), ctx)
 }
 
+// zypper-docker list-updates-container [flags] <container>
 func listUpdatesContainerCmd(ctx *cli.Context) {
 	containerId := ctx.Args().First()
 	container, err := checkContainerRunning(containerId)
@@ -37,12 +39,15 @@ func listUpdatesContainerCmd(ctx *cli.Context) {
 	listUpdates(container.Image, ctx)
 }
 
+// listUpdates lists all the updates available for the given image with the
+// given arguments.
 func listUpdates(image string, ctx *cli.Context) {
 	// It's safe to ignore the returned error because we set to false the
 	// `getError` parameter of this function.
 	_ = runStreamedCommand(image, "lu", false)
 }
 
+// zypper-docker update [flags] image new-image
 func updateCmd(ctx *cli.Context) {
 	if len(ctx.Args()) != 2 {
 		log.Println("Wrong invocation")

--- a/zypper-docker.go
+++ b/zypper-docker.go
@@ -16,10 +16,7 @@
 // in a safe way.
 package main
 
-import (
-	"log"
-	"os"
-)
+import "os"
 
 var exitWithCode func(code int)
 var killChannel chan bool
@@ -30,8 +27,6 @@ func main() {
 	exitWithCode = func(code int) {
 		os.Exit(code)
 	}
-
-	log.SetOutput(os.Stderr)
 
 	// Safe initialization of the singleton client instance. Take a look at the
 	// documentation of this function for more information.


### PR DESCRIPTION
By default zypper-docker will log everything into a hidden file inside of the
user's home directory. If the user passes the new -d/--debug flag, then the
logging will be done on the stdout.

Moreover, I've also modified some log messages to be more useful. Besides that,
I've done some polishing here and there regarding the documentation.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>