### PR TITLE
Use the proper HOME value for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,9 @@ all set to false by default:
 
 Note that some of these commands might be expensive. That's why some of the
 needed data is cached into a single file. This file is named
-`docker-zypper.json` and it can be located in either of these locations:
-
-1. $XDG\_CACHE\_HOME
-2. $XDG\_DATA\_DIRS
-3. $HOME/.cache
-4. /tmp
-
-The application will first try to allocate the cache on `$XDG_CACHE_HOME`. If
-it fails, it will try it on the next location, and so on.
+`docker-zypper.json`. This cache file normally resides inside of the
+`$HOME/.cache` directory. However, if there is some problem with this
+directory, it might get saved inside of the `/tmp` directory.
 
 ## Targetting Docker daemons running on remote machines
 
@@ -61,12 +55,6 @@ opensuse            latest              c7ff47bc7ebb        13 days ago         
 ```
 
 ## Operations available against Docker images
-
-**TODO**
-
-  * Specify the name of the final image `-t` like `docker build` maybe?
-  * Should we handle non-interactive stuff?
-
 
 ### List all the updates available
 

--- a/ps_test.go
+++ b/ps_test.go
@@ -17,8 +17,6 @@ package main
 import (
 	"bytes"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -59,16 +57,6 @@ func TestPsCommandListContaienrsEmpty(t *testing.T) {
 }
 
 func TestPsCommandNoMatches(t *testing.T) {
-	cache := os.Getenv("XDG_CACHE_HOME")
-	abs, _ := filepath.Abs(".")
-	test := filepath.Join(abs, "test")
-
-	defer func() {
-		_ = os.Setenv("XDG_CACHE_HOME", cache)
-	}()
-
-	_ = os.Setenv("XDG_CACHE_HOME", test)
-
 	setupTestExitStatus()
 	dockerClient = &mockClient{}
 
@@ -85,16 +73,6 @@ func TestPsCommandNoMatches(t *testing.T) {
 }
 
 func TestPsCommandMatches(t *testing.T) {
-	cache := os.Getenv("XDG_CACHE_HOME")
-	abs, _ := filepath.Abs(".")
-	test := filepath.Join(abs, "test")
-
-	defer func() {
-		_ = os.Setenv("XDG_CACHE_HOME", cache)
-	}()
-
-	_ = os.Setenv("XDG_CACHE_HOME", test)
-
 	cacheFile := getCacheFile()
 	cacheFile.Outdated = []string{"2"} // this is the Id of the opensuse:13.2 image
 	cacheFile.Other = []string{"3"}    // this is the Id of the ubuntu:latest image


### PR DESCRIPTION
This fixes a regression in which the wrong path for tests was being picked.
This caused some problems:

- Some tests were failing with `make test`.
- The cache from the host machine was being touched after performing `go test`.

Fixes #60

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>