### PR TITLE
The ID of the a patched or updated image is written to cache file.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -104,18 +104,23 @@ func (cd *cachedData) reset() {
 	cd.flush()
 }
 
-// Add the ID of the image identified by the provided name to the list
-// of the outdated images.
-func (cd *cachedData) addImageToListOfOutdatedOnes(name string) error {
-	imageId, err := getImageId(name)
+// Update the Cachefile after an update.
+// The ID of the outdated image will be added to outdated Images and
+// the ID of the new image will be added to the SUSE Images.
+func (cd *cachedData) updateCacheAfterUpdate(outdatedImg, updatedImgId string) error {
+	outdatedImgId, err := getImageId(outdatedImg)
 	if err != nil {
 		return err
 	}
-
-	if !arrayIncludeString(cd.Outdated, imageId) {
-		cd.Outdated = append(cd.Outdated, imageId)
+	if !arrayIncludeString(cd.Outdated, outdatedImgId) {
+		cd.Outdated = append(cd.Outdated, outdatedImgId)
 		cd.flush()
 	}
+	if !arrayIncludeString(cd.Suse, updatedImgId) {
+		cd.Suse = append(cd.Suse, updatedImgId)
+		cd.flush()
+	}
+
 	return nil
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -214,36 +214,40 @@ func TestFlush(t *testing.T) {
 	}
 }
 
-func TestAddImageToListOfOutdatedOnesFailsBecauseOfListError(t *testing.T) {
+func TestUpdateCacheAfterUpdateFailsBecauseOfListError(t *testing.T) {
 	cache := cachedData{}
 
 	dockerClient = &mockClient{listFail: true}
-	err := cache.addImageToListOfOutdatedOnes("1")
+	err := cache.updateCacheAfterUpdate("1", "2")
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
 }
 
-func TestAddImageToListOfOutdatedOnesFailsBecauseOfListEmpty(t *testing.T) {
+func TestUpdateCacheAfterUpdateFailsBecauseOfListEmpty(t *testing.T) {
 	cache := cachedData{}
 
 	dockerClient = &mockClient{listEmpty: true}
-	err := cache.addImageToListOfOutdatedOnes("1")
+	err := cache.updateCacheAfterUpdate("1", "2")
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
 }
 
-func TestAddImageToListOfOutdatedOnesNothingDoneWhenTheImageIsAlreadyKnown(t *testing.T) {
+func TestUpdateCacheAfterUpdateNothingDoneWhenTheImageIsAlreadyKnown(t *testing.T) {
 	cache := cachedData{
-		Outdated: []string{"35ae93c88cf8ab18da63bb2ad2dfd2399d745f292a344625fbb65892b7c25a01"}}
+		Outdated: []string{"35ae93c88cf8ab18da63bb2ad2dfd2399d745f292a344625fbb65892b7c25a01"},
+		Suse:     []string{"2"}}
 
 	dockerClient = &mockClient{listEmpty: true}
-	err := cache.addImageToListOfOutdatedOnes("opensuse:13.2")
+	err := cache.updateCacheAfterUpdate("opensuse:13.2", "2")
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
 	if len(cache.Outdated) != 1 {
+		t.Fatal("Nothing should have changed")
+	}
+	if len(cache.Suse) != 1 {
 		t.Fatal("Nothing should have changed")
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -284,7 +284,7 @@ func TestRunCommandAndCommitToImageSuccess(t *testing.T) {
 	var err error
 
 	capture.All(func() {
-		err = runCommandAndCommitToImage(
+		_, err = runCommandAndCommitToImage(
 			"source",
 			"new_repo",
 			"new_tag",
@@ -303,7 +303,7 @@ func TestRunCommandAndCommitToImageRunFailure(t *testing.T) {
 	var err error
 
 	capture.All(func() {
-		err = runCommandAndCommitToImage(
+		_, err = runCommandAndCommitToImage(
 			"source",
 			"new_repo",
 			"new_tag",
@@ -325,7 +325,7 @@ func TestRunCommandAndCommitToImageCommitFailure(t *testing.T) {
 	var err error
 
 	capture.All(func() {
-		err = runCommandAndCommitToImage(
+		_, err = runCommandAndCommitToImage(
 			"source",
 			"new_repo",
 			"new_tag",

--- a/patches.go
+++ b/patches.go
@@ -80,7 +80,7 @@ func patchCmd(ctx *cli.Context) {
 	cmd := fmt.Sprintf(
 		"zypper ref && zypper -n %v",
 		cmdWithFlags("patch", ctx, boolFlags, toIgnore))
-	err = runCommandAndCommitToImage(
+	newImgId, err := runCommandAndCommitToImage(
 		img,
 		repo,
 		tag,
@@ -96,7 +96,7 @@ func patchCmd(ctx *cli.Context) {
 	log.Printf("%s:%s successfully created", repo, tag)
 
 	cache := getCacheFile()
-	if err := cache.addImageToListOfOutdatedOnes(img); err != nil {
+	if err := cache.updateCacheAfterUpdate(img, newImgId); err != nil {
 		log.Println("Cannot add image details to zypper-docker cache")
 		log.Println("This will break the \"zypper-docker ps\" feature")
 		log.Println(err)

--- a/updates.go
+++ b/updates.go
@@ -74,7 +74,7 @@ func updateCmd(ctx *cli.Context) {
 	cmd := fmt.Sprintf(
 		"zypper ref && zypper -n %v",
 		cmdWithFlags("up", ctx, boolFlags, toIgnore))
-	err = runCommandAndCommitToImage(
+	newImgId, err := runCommandAndCommitToImage(
 		img,
 		repo,
 		tag,
@@ -90,7 +90,7 @@ func updateCmd(ctx *cli.Context) {
 	log.Printf("%s:%s successfully created", repo, tag)
 
 	cache := getCacheFile()
-	if err := cache.addImageToListOfOutdatedOnes(img); err != nil {
+	if err := cache.updateCacheAfterUpdate(img, newImgId); err != nil {
 		log.Println("Cannot add image details to zypper-docker cache")
 		log.Println("This will break the \"zypper-docker ps\" feature")
 		log.Println(err)


### PR DESCRIPTION
Fixes #54

Signed-off-by: Jürgen Löhel <jloehel@suse.com>