### PR TITLE
Leave early when a signal comes for expensive commands

### DIFF
--- a/images.go
+++ b/images.go
@@ -43,18 +43,23 @@ func printImages(imgs []*dockerclient.Image) {
 
 	cache := getCacheFile()
 	for counter, img := range imgs {
-		fmt.Printf("Inspecting image %d/%d\r", (counter + 1), len(imgs))
-		if cache.isSUSE(img.Id) {
-			if len(img.RepoTags) < 1 {
-				continue
-			}
+		select {
+		case <-killChannel:
+			return
+		default:
+			fmt.Printf("Inspecting image %d/%d\r", (counter + 1), len(imgs))
+			if cache.isSUSE(img.Id) {
+				if len(img.RepoTags) < 1 {
+					continue
+				}
 
-			id := stringid.TruncateID(img.Id)
-			size := units.HumanSize(float64(img.VirtualSize))
-			for _, tag := range img.RepoTags {
-				t := strings.SplitN(tag, ":", 2)
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", t[0], t[1], id,
-					timeAgo(img.Created), size)
+				id := stringid.TruncateID(img.Id)
+				size := units.HumanSize(float64(img.VirtualSize))
+				for _, tag := range img.RepoTags {
+					t := strings.SplitN(tag, ":", 2)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", t[0], t[1], id,
+						timeAgo(img.Created), size)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The `images` and the `ps` commands are expensive since they can potentially
start a huge amount of containers. With this commit, when a signal comes in
the middle of the execution of these commands, said command will leave early.
Since the killing of the possibly generated container has already been done by
the `startContainer` function, and no containers will get created after the
signal gets fired, then we can be sure that the resulting environment will be
clean (we won't leave containers pending to be killed).

Anyways, this is a workaround on the issue #58. This commit does not make
zypper-docker to handle signals perfectly clean, but it's a "good enough"
solution for most cases. I've investigated quite a lot on this, and I've
realized that in order to properly fix this issue, some refactoring have to be
done in the codebase. For safety concerns, I'll do such refactorings after the
first version of zypper-docker is released. For now, this commit will suffice.

Fixes #58

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>