### PR TITLE
Always run zypper in non-interactive mode

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -64,10 +64,6 @@ func newApp() *cli.App {
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "n, non-interactive",
-			Usage: "Switches to non-interactive mode",
-		},
-		cli.BoolFlag{
 			Name:  "no-gpg-checks",
 			Usage: "Ignore GPG check failures and continue",
 		},

--- a/flags_test.go
+++ b/flags_test.go
@@ -25,7 +25,7 @@ func TestVersion(t *testing.T) {
 func TestNewApp(t *testing.T) {
 	app := newApp()
 
-	if len(app.Flags) != 6 {
+	if len(app.Flags) != 5 {
 		t.Fatal("Wrong number of global flags")
 	}
 	if len(app.Commands) != 10 {

--- a/helpers.go
+++ b/helpers.go
@@ -48,8 +48,8 @@ func globalFlags() string {
 		return ""
 	}
 
-	res := ""
-	flags := []string{"non-interactive", "no-gpg-checks", "gpg-auto-import-keys"}
+	res := "--non-interactive "
+	flags := []string{"no-gpg-checks", "gpg-auto-import-keys"}
 
 	for _, v := range flags {
 		if currentContext.GlobalBool(v) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -209,7 +209,7 @@ func TestFormatZypperCommand(t *testing.T) {
 		os.Args = originalArgs
 		currentContext = nil
 	}()
-	os.Args = []string{"exe", "--non-interactive", "--add-host", "host:ip", "test"}
+	os.Args = []string{"exe", "--add-host", "host:ip", "test"}
 
 	app := newApp()
 	app.Commands = []cli.Command{{Name: "test", Action: getCmd("test", func(*cli.Context) {})}}

--- a/man/zypper-docker.1.md
+++ b/man/zypper-docker.1.md
@@ -30,9 +30,6 @@ just run **man zypper-docker <command>**.
 **--help**, **-h**
   Show the help message.
 
-**-n**, **--non-interactive**
-  Switches to non-interactive mode. This means that if this option is set to true, zypper\-docker will choose the default option whenever a question is prompted to the user.
-
 **--no-gpg-checks**
   Ignore GPG check failures and continue
 


### PR DESCRIPTION
We don't attach to the stdin yet, so it's pretty useless to be in
interactive mode.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>