### PR TITLE
Increased the timeout for containers

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,7 +72,7 @@ const (
 
 	// The timeout in which the container is allowed to run a command as given
 	// to the `startContainer` function.
-	containerTimeout = 2 * time.Second
+	containerTimeout = 15 * time.Second
 
 	// tls-related files, code taken from docker/common.go
 	defaultTrustKeyFile = "key.json"


### PR DESCRIPTION
Some valid images are a bit slow to execute the zypper command. This commit
fixes this by just increasing a bit the timeout.

Fixes #76

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>