### PR TITLE
The patch and the update commands no longer pollute the resulting image

### DIFF
--- a/Godeps/_workspace/src/github.com/SUSE/dockerclient/dockerclient.go
+++ b/Godeps/_workspace/src/github.com/SUSE/dockerclient/dockerclient.go
@@ -781,7 +781,7 @@ func (client *DockerClient) BuildImage(image *BuildImage) (io.ReadCloser, error)
 	return client.doStreamRequest("POST", uri, image.Context, headers)
 }
 
-func (client *DockerClient) Commit(id string, c *ContainerConfig, repo, tag, comment, author string) (string, error) {
+func (client *DockerClient) Commit(id string, c *ContainerConfig, repo, tag, comment, author string, changes []string) (string, error) {
 	config, err := json.Marshal(c)
 	if err != nil {
 		return "", err
@@ -793,6 +793,9 @@ func (client *DockerClient) Commit(id string, c *ContainerConfig, repo, tag, com
 	v.Set("tag", tag)
 	v.Set("comment", comment)
 	v.Set("author", author)
+	for _, change := range changes {
+		v.Add("changes", change)
+	}
 
 	uri := fmt.Sprintf("/%s/commit?%s", APIVersion, v.Encode())
 	data, err := client.doRequest("POST", uri, config, nil)

--- a/docker/Dockerfile-entrypoint-and-cmd-set
+++ b/docker/Dockerfile-entrypoint-and-cmd-set
@@ -1,0 +1,8 @@
+# This Dockerfile produces an simple image with a cmd and an entrypoint set.
+# This is what we need to test that the patch/update operations do not modify
+# them.
+
+FROM opensuse:13.2
+
+CMD ["/etc/os-release"]
+ENTRYPOINT ["cat"]

--- a/helpers.go
+++ b/helpers.go
@@ -287,7 +287,7 @@ func updatePatchCmd(zypperCmd string, ctx *cli.Context) {
 		return
 	}
 
-	logAndPrintf("%s:%s successfully created", repo, tag)
+	logAndPrintf("%s:%s successfully created\n", repo, tag)
 
 	cache := getCacheFile()
 	if err := cache.updateCacheAfterUpdate(img, newImgID); err != nil {
@@ -296,4 +296,21 @@ func updatePatchCmd(zypperCmd string, ctx *cli.Context) {
 		log.Println(err)
 		exitWithCode(1)
 	}
+}
+
+// joinAsArray joins the given array of commands so it's compatible to what is
+// expected from a dockerfile syntax.
+func joinAsArray(cmds []string, emptyArray bool) string {
+	if emptyArray && len(cmds) == 0 {
+		return ""
+	}
+
+	str := "["
+	for i, v := range cmds {
+		str += "\"" + v + "\""
+		if i < len(cmds)-1 {
+			str += ", "
+		}
+	}
+	return str + "]"
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -247,3 +247,22 @@ func TestFormatZypperCommand(t *testing.T) {
 		t.Fatalf("Wrong command '%v', expected '%v'", cmd, expected)
 	}
 }
+
+func TestJoinAsArray(t *testing.T) {
+	str := joinAsArray([]string{}, false)
+	if str != "[]" {
+		t.Fatalf("Expected '[]', got: %s", str)
+	}
+	str = joinAsArray([]string{}, true)
+	if str != "" {
+		t.Fatalf("Expected '', got: %s", str)
+	}
+	str = joinAsArray([]string{"one"}, false)
+	if str != "[\"one\"]" {
+		t.Fatalf("Expected '[\"one\"]', got: %s", str)
+	}
+	str = joinAsArray([]string{"one", "two"}, false)
+	if str != "[\"one\", \"two\"]" {
+		t.Fatalf("Expected '[\"one\", \"two\"]', got: %s", str)
+	}
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -40,6 +40,7 @@ type mockClient struct {
 	lastCmd            []string
 	killFail           bool
 	commitFail         bool
+	inspectFail        bool
 }
 
 func (mc *mockClient) ListImages(all bool, filter string, filters *dockerclient.ListFilter) ([]*dockerclient.Image, error) {
@@ -176,7 +177,7 @@ func (mc *mockClient) KillContainer(id, signal string) error {
 	return nil
 }
 
-func (mc *mockClient) Commit(id string, c *dockerclient.ContainerConfig, repo, tag, comment, author string) (string, error) {
+func (mc *mockClient) Commit(id string, c *dockerclient.ContainerConfig, repo, tag, comment, author string, changes []string) (string, error) {
 	if mc.commitFail {
 		return "", fmt.Errorf("Fake failure while committing container")
 	}
@@ -220,4 +221,11 @@ func (mc *mockClient) ListContainers(all bool, size bool, filters string) ([]doc
 func (mc *mockClient) ResizeContainer(id string, isExec bool, width, height int) error {
 	// Do nothing
 	return nil
+}
+
+func (mc *mockClient) InspectImage(id string) (*dockerclient.ImageInfo, error) {
+	if mc.inspectFail {
+		return nil, errors.New("inspect fail!")
+	}
+	return &dockerclient.ImageInfo{Config: &dockerclient.ContainerConfig{Image: "1"}}, nil
 }

--- a/patches_test.go
+++ b/patches_test.go
@@ -26,6 +26,7 @@ func TestPatchCommand(t *testing.T) {
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag.", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed.", ""},
 		{"Cannot update cache", &mockClient{}, 1, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
+		{"Cannot inspect", &mockClient{inspectFail: true}, 1, []string{"opensuse:13.2", "new:1.0.0"}, true, "could not inspect image 'opensuse:13.2': inspect fail!", ""},
 		{"Patch success", &mockClient{listReturnOneImage: true}, 0, []string{"opensuse:13.2", "new:1.0.0"}, true, "new:1.0.0 successfully created", ""},
 	}
 	cases.run(t, patchCmd, "zypper -n patch", "")

--- a/spec/update_operations_spec.rb
+++ b/spec/update_operations_spec.rb
@@ -50,6 +50,30 @@ describe "update operations" do
       expect(output).not_to include("alsa-utils")
 
       check_commit_details(author, message, @patched_image)
+      expect(docker_inspect(@patched_image, ".Config.Entrypoint")).to eq "{[]}"
+      expect(docker_inspect(@patched_image, ".Config.Cmd")).to eq "{[/bin/sh -c]}"
+    end
+
+    it "does not overwrite the contents of the cmd and entrypoint" do
+      @image_tag = "1.0"
+      @image = "#{Settings::ENTRY_CMD_IMAGE_REPO}:#{@image_tag}"
+
+      if docker_image_exists?(Settings::ENTRY_CMD_IMAGE_REPO, @image_tag)
+        remove_docker_image(@image)
+      end
+
+      out = Cheetah.run(
+        "zypper-docker", "up",
+        "--author", author,
+        "--message", message,
+        Settings::ENTRY_CMD_IMAGE,
+        @image)
+
+      expect(docker_image_exists?(Settings::ENTRY_CMD_IMAGE_REPO, @image_tag)).to be true
+
+      check_commit_details(author, message, @image)
+      expect(docker_inspect(@image, ".Config.Entrypoint")).to eq "{[cat]}"
+      expect(docker_inspect(@image, ".Config.Cmd")).to eq "{[/etc/os-release]}"
     end
 
     it "refuses to overwrite an existing image while doing an update" do


### PR DESCRIPTION
Before this patch, the patch/update commands wrongfully messed up some
properties from the original one that had to be left untouched. These being:
entrypoint, cmd and hostname.

Fixes #75

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>