### PR TITLE
client: run all zypper commands as root

### DIFF
--- a/docker/Dockerfile-normal-user
+++ b/docker/Dockerfile-normal-user
@@ -1,0 +1,6 @@
+# This Dockerfile sets the USER of the image, to ensure that zypper-docker runs
+# zypper as root and then resets it back to the previous USER.
+
+FROM opensuse:13.2
+
+USER 1337:1337

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -13,6 +13,10 @@ class Settings
   ENTRY_CMD_IMAGE_REPO = "zypper-docker-tests-entrypoint-cmd-image"
   ENTRY_CMD_IMAGE_TAG = "0.1"
   ENTRY_CMD_IMAGE = "#{ENTRY_CMD_IMAGE_REPO}:#{ENTRY_CMD_IMAGE_TAG}"
+
+  NORMAL_USER_IMAGE_REPO = "zypper-docker-tests-normal-user-image"
+  NORMAL_USER_IMAGE_TAG = "0.1"
+  NORMAL_USER_IMAGE = "#{NORMAL_USER_IMAGE_REPO}:#{NORMAL_USER_IMAGE_TAG}"
 end
 
 module SpecHelper
@@ -70,6 +74,10 @@ module SpecHelper
     ensure_image_exists(Settings::ENTRY_CMD_IMAGE, "Dockerfile-entrypoint-and-cmd-set")
   end
 
+  def ensure_normal_user_image_exists
+    ensure_image_exists(Settings::NORMAL_USER_IMAGE, "Dockerfile-normal-user")
+  end
+
   def remove_docker_image(image)
     Cheetah.run("docker", "rmi", "-f", image)
   end
@@ -115,5 +123,6 @@ RSpec.configure do |config|
   config.before :all do
     ensure_vulnerable_image_exists
     ensure_entrypoint_cmd_image_exists
+    ensure_normal_user_image_exists
   end
 end

--- a/spec/patches_operations_spec.rb
+++ b/spec/patches_operations_spec.rb
@@ -194,7 +194,7 @@ describe "patch operations" do
           remove_docker_image(@image)
         end
 
-        out = Cheetah.run(
+        Cheetah.run(
           "zypper-docker", "patch",
           "--author", author,
           "--message", message,
@@ -206,6 +206,27 @@ describe "patch operations" do
         check_commit_details(author, message, @image)
         expect(docker_inspect(@image, ".Config.Entrypoint")).to eq "{[cat]}"
         expect(docker_inspect(@image, ".Config.Cmd")).to eq "{[/etc/os-release]}"
+      end
+
+      it "can run zypper on a non-root image and reset the user afterwards" do
+        @image_tag = "1.0"
+        @image = "#{Settings::NORMAL_USER_IMAGE_REPO}:#{@image_tag}"
+
+        if docker_image_exists?(Settings::NORMAL_USER_IMAGE_REPO, @image_tag)
+          remove_docker_image(@image)
+        end
+
+        Cheetah.run(
+          "zypper-docker", "patch",
+          "--author", author,
+          "--message", message,
+          Settings::NORMAL_USER_IMAGE,
+          @image)
+
+        expect(docker_image_exists?(Settings::NORMAL_USER_IMAGE_REPO, @image_tag)).to be true
+
+        check_commit_details(author, message, @image)
+        expect(docker_inspect(@image, ".Config.User")).to eq "1337:1337"
       end
     end
 


### PR DESCRIPTION
This ensures that for containers which have specified a USER to run as
(such as in a Dockerfile), we can still run our commands as that user.
Unfortunately, we also have to revert the USER afterwards.

Fixes #91 

Signed-off-by: Aleksa Sarai <asarai@suse.com>