### PR TITLE
Display error message when image does not exist

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,6 +164,7 @@ func runStreamedCommand(img, cmd string, getError bool) error {
 	}
 	if err != nil {
 		log.Printf("Error: %s\n", err)
+		fmt.Println(err)
 		exitWithCode(1)
 	}
 	return nil


### PR DESCRIPTION
Print a meaningful error message to stdout instead of only providing a
return value.

Fixes #94

Signed-off-by: Thomas Hipp <thipp@suse.com>