### PR TITLE
Clean zypper's cache after patch or update

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -278,7 +278,7 @@ func updatePatchCmd(zypperCmd string, ctx *cli.Context) {
 		"replacefiles"}
 	toIgnore := []string{"author", "message"}
 
-	cmd := formatZypperCommand("ref", fmt.Sprintf("-n %v", zypperCmd))
+	cmd := formatZypperCommand("ref", fmt.Sprintf("-n %v", zypperCmd), "clean -a")
 	cmd = cmdWithFlags(cmd, ctx, boolFlags, toIgnore)
 	newImgID, err := runCommandAndCommitToImage(
 		img,


### PR DESCRIPTION
After patching or updating, the cache is cleanup by calling `zypper
clean -a`.

Resolves #80 

Signed-off-by: Thomas Hipp <thipp@suse.com>