### PR TITLE
Add `--severity` flag to `list-patches`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -64,7 +64,7 @@ func TestRunCommandInContainerCreateFailure(t *testing.T) {
 
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
-	if _, err := runCommandInContainer("fail", []string{}, false); err == nil {
+	if _, err := runCommandInContainer("fail", []string{}, nil); err == nil {
 		t.Fatal("It should've failed\n")
 	}
 
@@ -100,7 +100,7 @@ func TestRunCommandInContainerContainerLogsFailure(t *testing.T) {
 
 	buffer := bytes.NewBuffer([]byte{})
 	log.SetOutput(buffer)
-	_, err := runCommandInContainer("opensuse", []string{"zypper"}, true)
+	_, err := runCommandInContainer("opensuse", []string{"zypper"}, os.Stdout)
 	if err == nil {
 		t.Fatal("It should have failed\n")
 	}
@@ -116,7 +116,7 @@ func TestRunCommandInContainerStreaming(t *testing.T) {
 
 	var err error
 	resp := capture.All(func() {
-		_, err = runCommandInContainer("opensuse", []string{"foo"}, true)
+		_, err = runCommandInContainer("opensuse", []string{"foo"}, os.Stdout)
 	})
 	if err != nil {
 		t.Fatal("It shouldn't have failed")
@@ -136,7 +136,7 @@ func TestRunCommandInContainerCommandFailure(t *testing.T) {
 	var err error
 
 	capture.All(func() {
-		_, err = runCommandInContainer("busybox", []string{"zypper"}, false)
+		_, err = runCommandInContainer("busybox", []string{"zypper"}, nil)
 	})
 
 	if err == nil {

--- a/flags.go
+++ b/flags.go
@@ -163,6 +163,11 @@ func newApp() *cli.App {
 					Value: "",
 					Usage: "List only patches with this category.",
 				},
+				cli.StringFlag{
+					Name:  "severity",
+					Value: "",
+					Usage: "List only patches with this severity.",
+				},
 			},
 		},
 		{

--- a/helpers.go
+++ b/helpers.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"strings"
@@ -318,4 +319,23 @@ func joinAsArray(cmds []string, emptyArray bool) string {
 		}
 	}
 	return str + "]"
+}
+
+// supportsSeverityFlag checks whether or not zypper's `list-patches` command
+// supports the `--severity` flag in the specified image.
+func supportsSeverityFlag(image string) bool {
+	buf := bytes.NewBuffer([]byte{})
+	id, err := runCommandInContainer(image, []string{"zypper lp --severity"}, buf)
+	defer removeContainer(id)
+
+	if strings.Contains(buf.String(), "Missing argument for --severity") {
+		return true
+	}
+	if strings.Contains(buf.String(), "Unknown option '--severity'") {
+		return false
+	}
+	if err != nil {
+		log.Println("Unable to run zypper in container:", err)
+	}
+	return false
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -269,3 +269,19 @@ func TestJoinAsArray(t *testing.T) {
 		t.Fatalf("Expected '[\"one\", \"two\"]', got: %s", str)
 	}
 }
+
+func TestSupportsSeverityFlagFail(t *testing.T) {
+	safeClient.client = &mockClient{zypperBadVersion: true, suppressLog: true}
+
+	if supportsSeverityFlag("opensuse") {
+		t.Fatalf("supportsSeverityFlag should've returned false")
+	}
+}
+
+func TestSupportsSeverityFlagSuccess(t *testing.T) {
+	safeClient.client = &mockClient{zypperGoodVersion: true, suppressLog: true}
+
+	if !supportsSeverityFlag("opensuse") {
+		t.Fatalf("supportsSeverityFlag should've returned true")
+	}
+}

--- a/man/zypper-docker-lp.1.md
+++ b/man/zypper-docker-lp.1.md
@@ -40,5 +40,8 @@ the running container is based on.
 **-g**, **--category**
   List only patches with this category.
 
+**--severity**
+  List only patches with this severity. Note that this requires zypper >= 1.12.6 inside of your docker image.
+
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>

--- a/patches.go
+++ b/patches.go
@@ -14,7 +14,12 @@
 
 package main
 
-import "github.com/codegangsta/cli"
+import (
+	"fmt"
+	"log"
+
+	"github.com/codegangsta/cli"
+)
 
 // zypper-docker list-patches [flags] <image>
 func listPatchesCmd(ctx *cli.Context) {
@@ -31,6 +36,14 @@ func listPatchesContainerCmd(ctx *cli.Context) {
 // listParches calls the `zypper lp` command for the given image and the given
 // arguments.
 func listPatches(image string, ctx *cli.Context) {
+	if severity := ctx.String("severity"); severity != "" {
+		if !supportsSeverityFlag(image) {
+			log.Println("the --severity flag is only available for zypper versions >= 1.12.6")
+			fmt.Println("the --severity flag is only available for zypper versions >= 1.12.6")
+			exitWithCode(1)
+		}
+	}
+
 	// It's safe to ignore the returned error because we set to false the
 	// `getError` parameter of this function.
 	_ = runStreamedCommand(


### PR DESCRIPTION
If the `--severity` flag is set, it is determined whether or not the
flag is supported by the image's zypper version. Should the version be
too old (version < 1.12.6), it fails fast and prints an error message.

Resolves #70

Signed-off-by: Thomas Hipp <thipp@suse.com>