### PR TITLE
fix confusing error message with list-patches

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -323,19 +323,16 @@ func joinAsArray(cmds []string, emptyArray bool) string {
 
 // supportsSeverityFlag checks whether or not zypper's `list-patches` command
 // supports the `--severity` flag in the specified image.
-func supportsSeverityFlag(image string) bool {
+func supportsSeverityFlag(image string) (bool, error) {
 	buf := bytes.NewBuffer([]byte{})
 	id, err := runCommandInContainer(image, []string{"zypper lp --severity"}, buf)
 	defer removeContainer(id)
 
 	if strings.Contains(buf.String(), "Missing argument for --severity") {
-		return true
+		return true, nil
 	}
 	if strings.Contains(buf.String(), "Unknown option '--severity'") {
-		return false
+		return false, nil
 	}
-	if err != nil {
-		log.Println("Unable to run zypper in container:", err)
-	}
-	return false
+	return false, err
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -273,15 +273,26 @@ func TestJoinAsArray(t *testing.T) {
 func TestSupportsSeverityFlagFail(t *testing.T) {
 	safeClient.client = &mockClient{zypperBadVersion: true, suppressLog: true}
 
-	if supportsSeverityFlag("opensuse") {
-		t.Fatalf("supportsSeverityFlag should've returned false")
+	ok, err := supportsSeverityFlag("opensuse")
+	if ok && err != nil {
+		t.Fatalf("supportsSeverityFlag should've returned false with err == nil")
 	}
 }
 
 func TestSupportsSeverityFlagSuccess(t *testing.T) {
 	safeClient.client = &mockClient{zypperGoodVersion: true, suppressLog: true}
 
-	if !supportsSeverityFlag("opensuse") {
+	ok, _ := supportsSeverityFlag("opensuse")
+	if !ok {
 		t.Fatalf("supportsSeverityFlag should've returned true")
+	}
+}
+
+func TestSupportsSeverityFlagDockerError(t *testing.T) {
+	safeClient.client = &mockClient{startFail: true, suppressLog: true}
+
+	ok, err := supportsSeverityFlag("opensuse")
+	if ok && err == nil {
+		t.Fatalf("supportsSeverityFlag should've returned false with error != nil")
 	}
 }

--- a/patches.go
+++ b/patches.go
@@ -37,9 +37,14 @@ func listPatchesContainerCmd(ctx *cli.Context) {
 // arguments.
 func listPatches(image string, ctx *cli.Context) {
 	if severity := ctx.String("severity"); severity != "" {
-		if !supportsSeverityFlag(image) {
-			log.Println("the --severity flag is only available for zypper versions >= 1.12.6")
-			fmt.Println("the --severity flag is only available for zypper versions >= 1.12.6")
+		if ok, err := supportsSeverityFlag(image); !ok {
+			if err == nil {
+				log.Println("the --severity flag is only available for zypper versions >= 1.12.6")
+				fmt.Println("the --severity flag is only available for zypper versions >= 1.12.6")
+			} else {
+				log.Println(err)
+				fmt.Println(err)
+			}
 			exitWithCode(1)
 		}
 	}


### PR DESCRIPTION
When using the `--severity` flag with list-patches, a correct error
message is presented when e.g. the image is not available.
The error message indicating an old zypper version is only shown if that
is actually the case.

Fixes #102

Signed-off-by: Thomas Hipp <thipp@suse.com>