### PR TITLE
check image before running lp

### DIFF
--- a/patches.go
+++ b/patches.go
@@ -36,6 +36,11 @@ func listPatchesContainerCmd(ctx *cli.Context) {
 // listParches calls the `zypper lp` command for the given image and the given
 // arguments.
 func listPatches(image string, ctx *cli.Context) {
+	if image == "" {
+		logAndFatalf("Error: no image name specified.\n")
+		exitWithCode(1)
+	}
+
 	if severity := ctx.String("severity"); severity != "" {
 		if ok, err := supportsSeverityFlag(image); !ok {
 			if err == nil {


### PR DESCRIPTION
`listPatches` checks the image argument before proceeding further, to
prevent missleading error messages.

Fixes #106

Signed-off-by: Thomas Hipp <thipp@suse.com>