### PR TITLE
remove deprecated go vet tool fetch in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang
 
 RUN go get golang.org/x/tools/cmd/cover
-RUN go get golang.org/x/tools/cmd/vet
 RUN go get github.com/golang/lint/golint
 RUN curl -sL -o /usr/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /usr/bin/gimme

--- a/helpers.go
+++ b/helpers.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -200,10 +201,10 @@ func preventImageOverwrite(repo, tag string) error {
 	imageExists, err := checkImageExists(repo, tag)
 
 	if err != nil {
-		return fmt.Errorf("Cannot proceed safely: %v.", err)
+		return fmt.Errorf("cannot proceed safely: %v", err)
 	}
 	if imageExists {
-		return fmt.Errorf("Cannot overwrite an existing image. Please use a different repository/tag.")
+		return errors.New("cannot overwrite an existing image. Please use a different repository/tag")
 	}
 	return nil
 }

--- a/images_test.go
+++ b/images_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 
 func TestImagesCommand(t *testing.T) {
 	cases := testCases{
-		{"List fail", &mockClient{listFail: true}, 1, []string{}, false, "Cannot proceed safely: List Failed", ""},
+		{"List fail", &mockClient{listFail: true}, 1, []string{}, false, "cannot proceed safely: List Failed", ""},
 		{"Empty list of images", &mockClient{listEmpty: true}, 0, []string{}, false, "", "REPOSITORY"},
 	}
 	cases.run(t, imagesCmd, "", "")

--- a/patches_test.go
+++ b/patches_test.go
@@ -22,7 +22,7 @@ func TestPatchCommand(t *testing.T) {
 	cases := testCases{
 		{"Wrong number of arguments", &mockClient{}, 1, []string{}, true, "Wrong invocation: expected 2 arguments, 0 given.", ""},
 		{"Wrong format of image name", &mockClient{}, 1, []string{"ori", "dollar$$"}, true, "Could not parse 'dollar$$': invalid reference format", ""},
-		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot proceed safely: List Failed.", ""},
+		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "cannot proceed safely: List Failed.", ""},
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag.", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed.", ""},
 		{"Cannot update cache", &mockClient{}, 1, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},

--- a/updates_test.go
+++ b/updates_test.go
@@ -22,7 +22,7 @@ func TestUpdateCommand(t *testing.T) {
 	cases := testCases{
 		{"Wrong number of arguments", &mockClient{}, 1, []string{}, true, "Wrong invocation: expected 2 arguments, 0 given.", ""},
 		{"Wrong format of image name", &mockClient{}, 1, []string{"ori", "dollar$$"}, true, "Could not parse 'dollar$$': invalid reference format", ""},
-		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot proceed safely: List Failed.", ""},
+		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "cannot proceed safely: List Failed.", ""},
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag.", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed.", ""},
 		{"Cannot update cache", &mockClient{}, 1, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},


### PR DESCRIPTION
currently the project fails to build.
go vet tool has been removed and included in go, it's no longer accessible at: https://godoc.org/golang.org/x/tools/cmd