### PR TITLE
Added fix in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang
 
 RUN go get golang.org/x/tools/cmd/cover
-RUN go get golang.org/x/tools/cmd/vet
 RUN go get github.com/golang/lint/golint
 RUN curl -sL -o /usr/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
 RUN chmod +x /usr/bin/gimme


### PR DESCRIPTION
This PR is in reference to #115 , since , in the lastest go package, vet has been added in default, therefore no need to import this package and by removing this package, the build was successfully executed.