### PR TITLE
zypper.go: update zypper exit codes

### DIFF
--- a/zypper.go
+++ b/zypper.go
@@ -28,28 +28,18 @@ const (
 	zypperExitInfSecUpdateNeeded = 101
 	zypperExitInfRebootNeeded    = 102
 	zypperExitInfRestartNeeded   = 103
-	zypperExitIndCapNotFound     = 104
+	zypperExitInfCapNotFound     = 104
 	zypperExitOnSignal           = 105
+	zypperExitInfReposSkipped    = 106
 )
 
-// Given zypper's exit code returns true if the error is
-// a severe one. False otherwise. Severe errors will cause
-// zypper-docker to exit with error.
+// isZypperExitCodeSevere returns true if errCode is a severe zypper error
+// code, and will cause zypper-docker to exit with error.
 func isZypperExitCodeSevere(errCode int) bool {
-	switch errCode {
-	case zypperExitOK:
-		return false
-	case zypperExitInfRebootNeeded:
-		return false
-	case zypperExitInfUpdateNeeded:
-		return false
-	case zypperExitInfSecUpdateNeeded:
-		return false
-	case zypperExitInfRestartNeeded:
-		return false
-	case zypperExitOnSignal:
-		return false
-	default:
+	// Codes below 100 denote an error, codes above 100 provide a specific
+	// information, 0 represents a normal successful run.
+	if errCode > 0 && errCode < 100 {
 		return true
 	}
+	return false
 }

--- a/zypper_test.go
+++ b/zypper_test.go
@@ -25,7 +25,10 @@ func TestIsZypperExitCodeSevere(t *testing.T) {
 		zypperExitInfUpdateNeeded,
 		zypperExitInfSecUpdateNeeded,
 		zypperExitInfRestartNeeded,
+		zypperExitInfCapNotFound,
 		zypperExitOnSignal,
+		zypperExitInfReposSkipped,
+		666,
 	}
 
 	for _, code := range notSevereExitCodes {
@@ -43,8 +46,8 @@ func TestIsZypperExitCodeSevere(t *testing.T) {
 		zypperExitNoRepos,
 		zypperExitZyppLocked,
 		zypperExitErrCommit,
-		zypperExitIndCapNotFound,
-		127,
+		42,
+		99,
 	}
 
 	for _, code := range severeExitCodes {


### PR DESCRIPTION
Add the zypper exit code `ZYPPER_EXIT_INF_REPOS_SKIPPED`, fix typo s/Ind/Inf/, and rewrite `isZypperExitCodeSevere()` to make a simple range check instead of having switch-case branches.

See zypper's manpages:
"Codes below 100 denote an error, codes above 100 provide a specific information, 0 represents a normal successful run."

Note that `ZYPPER_EXIT_INF_CAP_NOT_FOUND` is now classified as a non-severe exit code (see description above). Zypper doesn't exit when a non-existent package has been detected.

Fixes: https://github.com/SUSE/zypper-docker/issues/112
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>