### PR TITLE
zypper-docker: use zypper's exit code

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,9 @@ import (
 	"github.com/docker/engine-api/types/strslice"
 )
 
+// zypperExitCode is used as zypper-docker's exit code.
+var zypperExitCode int
+
 // rootUser is the explicit value to use for the USER directive to specify a user
 // as being root. Oddly, specifying the default value ("") doesn't work even though
 // images that have the default value set for .Config.User run as root.
@@ -245,6 +248,7 @@ func startContainer(img string, cmd []string, wait bool, dst io.Writer) (string,
 
 	select {
 	case res := <-containerWait(id):
+		zypperExitCode = res.exitCode
 		if dst != nil {
 			<-sc
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -300,7 +300,6 @@ func updatePatchCmd(zypperCmd string, ctx *cli.Context) {
 		log.Println("Cannot add image details to zypper-docker cache")
 		log.Println("This will break the \"zypper-docker ps\" feature")
 		log.Println(err)
-		exitWithCode(1)
 	}
 }
 

--- a/patches_test.go
+++ b/patches_test.go
@@ -25,7 +25,7 @@ func TestPatchCommand(t *testing.T) {
 		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot proceed safely: List Failed", ""},
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed", ""},
-		{"Cannot update cache", &mockClient{}, 1, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
+		{"Cannot update cache", &mockClient{}, 0, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
 		{"Cannot inspect", &mockClient{inspectFail: true}, 1, []string{"opensuse:13.2", "new:1.0.0"}, true, "could not inspect image 'opensuse:13.2': inspect fail", ""},
 		{"Patch success", &mockClient{listReturnOneImage: true}, 0, []string{"opensuse:13.2", "new:1.0.0"}, true, "new:1.0.0 successfully created", ""},
 	}

--- a/updates_test.go
+++ b/updates_test.go
@@ -25,7 +25,7 @@ func TestUpdateCommand(t *testing.T) {
 		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot proceed safely: List Failed", ""},
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed", ""},
-		{"Cannot update cache", &mockClient{}, 1, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
+		{"Cannot update cache", &mockClient{}, 0, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
 		{"Update success", &mockClient{listReturnOneImage: true}, 0, []string{"opensuse:13.2", "new:1.0.0"}, true, "new:1.0.0 successfully created", ""},
 	}
 	cases.run(t, updateCmd, "zypper -n up", "")

--- a/zypper-docker.go
+++ b/zypper-docker.go
@@ -31,4 +31,7 @@ func main() {
 	os.Args = fixArgsForZypper(os.Args)
 	app := newApp()
 	app.RunAndExitOnError()
+
+	// TODO: add tests to check for correctly passing exit codes
+	os.Exit(zypperExitCode)
 }


### PR DESCRIPTION
Use zypper's exit code to indicate the status of executed commands, which is needed for automation. Note that exit code `1` now indicates either an unexpected error/bug in zypper or zypper-docker. With this change, zypper-docker returns zypper's exit code.

Such a change is needed to use zypper-docker in a more automated fashion. Hence, we need to pass zypper's exit code to the user, so that she can react accordingly.

Please note that there is no tests yet for this change. I suggest to add them along with rewriting the test suite (see https://github.com/SUSE/zypper-docker/issues/119).

Fixes: bsc#1018823
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>