### PR TITLE
Fix update behavior when getting a zypper-related update

### DIFF
--- a/man/zypper-docker-up.1.md
+++ b/man/zypper-docker-up.1.md
@@ -9,9 +9,11 @@ zypper\-docker update \- Install the available updates for the given image.
 
 # DESCRIPTION
 The **update** command updates the given openSUSE/SUSE Linux Enterprise image
-with all the available updates. The updated image will have a new name, as
-provided by the NEW-IMAGE argument. Note that both the IMAGE and the NEW\-IMAGE
-arguments have to follow Docker's naming format.
+with all the available updates. If there is a zypper-related update, which returns
+the exit code 103 (ZYPPER_EXIT_INF_RESTART_NEEDED), zypper-docker goes through the 
+update process once again, to install the remaining updates.
+The updated image will have a new name, as provided by the NEW-IMAGE argument.
+Note that both the IMAGE and the NEW\-IMAGE arguments have to follow Docker's naming format.
 
 To list all the updates available for a given image, use the **list-updates**
 and the **list-updates-container** commands. To show all the images based on


### PR DESCRIPTION
Fix the semantics of 'client.go', so that a second update process is executed, when a zypper-related update (with exitcode 103) was installed.
Change the explanation of the update process in the manpage.

Fix #110 .

Signed-off-by: Fabian Baumanis <fabian.baumanis@suse.com>