### PR TITLE
Travis CI: go 1.9, 1.10.x, tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ services:
 
 language: go
 go:
-  - 1.6
-  - 1.7
-  - 1.8
+  - 1.9
+  - 1.10.x
   - tip
 
 env:


### PR DESCRIPTION
Use more recent versions of go.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>