### PR TITLE
Fixes a bug that causes lpc command to log to stdout

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -201,7 +201,7 @@ If the tag has not been provided, then "latest" is the one that will be used.`,
 			ShortName: "lpc",
 			Aliases:   []string{"lpc"},
 			Usage:     "List all the available patches for the given container",
-			Action:    listPatchesContainerCmd,
+			Action:    getCmd("list-patches-container", listPatchesContainerCmd),
 			ArgsUsage: `<container-id>
 
 Where <container-id> is either the container ID or the name of the container


### PR DESCRIPTION
When calling `zypper-docker lpc` the `listPatchesContainerCmd(...)`
function is not called via the `getCmd` function which causes the
logger to not be setup. As a result the logged massages are printed
to `os.Stdout`.
This commit fixes this issue.

Signed-off-by: Pascal Arlt <parlt@suse.com>