### PR TITLE
Fix the docker ps command

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -219,17 +219,7 @@ func TestFlush(t *testing.T) {
 func TestUpdateCacheAfterUpdateFailsBecauseOfListError(t *testing.T) {
 	cache := cachedData{}
 
-	safeClient.client = &mockClient{listFail: true}
-	err := cache.updateCacheAfterUpdate("1", "2")
-	if err == nil {
-		t.Fatal("Expected failure")
-	}
-}
-
-func TestUpdateCacheAfterUpdateFailsBecauseOfListEmpty(t *testing.T) {
-	cache := cachedData{}
-
-	safeClient.client = &mockClient{listEmpty: true}
+	safeClient.client = &mockClient{inspectFail: true}
 	err := cache.updateCacheAfterUpdate("1", "2")
 	if err == nil {
 		t.Fatal("Expected failure")
@@ -241,7 +231,7 @@ func TestUpdateCacheAfterUpdateNothingDoneWhenTheImageIsAlreadyKnown(t *testing.
 		Outdated: []string{"35ae93c88cf8ab18da63bb2ad2dfd2399d745f292a344625fbb65892b7c25a01"},
 		Suse:     []string{"2"}}
 
-	safeClient.client = &mockClient{listEmpty: true}
+	safeClient.client = &mockClient{inspectFail: true}
 	err := cache.updateCacheAfterUpdate("opensuse:13.2", "2")
 	if err == nil {
 		t.Fatal("Expected failure")

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -89,14 +89,6 @@ func TestParseImageNameWrongFormat(t *testing.T) {
 	}
 }
 
-func TestGetImageIdErrorWhileParsingName(t *testing.T) {
-	_, err := getImageID("OPENSUSE")
-
-	if err == nil {
-		t.Fatalf("Should have failed")
-	}
-}
-
 func TestPreventImageOverwriteImageCheckImageFailure(t *testing.T) {
 	safeClient.client = &mockClient{listFail: true}
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -232,24 +232,28 @@ func (mc *mockClient) ContainerList(ctx context.Context, options types.Container
 
 	return []types.Container{
 		types.Container{
-			ID:    "35ae93c88cf8ab18da63bb2ad2dfd2399d745f292a344625fbb65892b7c25a01",
-			Names: []string{"/suse"},
-			Image: "opensuse:13.2",
+			ID:      "35ae93c88cf8ab18da63bb2ad2dfd2399d745f292a344625fbb65892b7c25a01",
+			Names:   []string{"/suse"},
+			Image:   "opensuse:13.2",
+			ImageID: "sha256:7f31a825a11ec6557fbddd5fea8b823a4709ee552233352e435b4840e14388bd",
 		},
 		types.Container{
-			ID:    "2",
-			Names: []string{"/not_suse"},
-			Image: "busybox:latest",
+			ID:      "2",
+			Names:   []string{"/not_suse"},
+			Image:   "busybox:latest",
+			ImageID: "2",
 		},
 		types.Container{
-			ID:    "3",
-			Names: []string{"/ubuntu"},
-			Image: "ubuntu:latest",
+			ID:      "3",
+			Names:   []string{"/ubuntu"},
+			Image:   "ubuntu:latest",
+			ImageID: "3",
 		},
 		types.Container{
-			ID:    "4",
-			Names: []string{"/unknown_image"},
-			Image: "foo",
+			ID:      "4",
+			Names:   []string{"/unknown_image"},
+			Image:   "foo",
+			ImageID: "4",
 		},
 	}, nil
 }
@@ -263,7 +267,7 @@ func (mc *mockClient) ImageInspectWithRaw(ctx context.Context, imageID string) (
 	if mc.inspectFail {
 		return types.ImageInspect{}, []byte{}, errors.New("inspect fail")
 	}
-	return types.ImageInspect{Config: &container.Config{Image: "1"}}, []byte{}, nil
+	return types.ImageInspect{ID: "1", Config: &container.Config{Image: "1"}}, []byte{}, nil
 }
 
 func (mc *mockClient) ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {

--- a/patches_test.go
+++ b/patches_test.go
@@ -24,7 +24,6 @@ func TestPatchCommand(t *testing.T) {
 		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot proceed safely: List Failed", ""},
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed", ""},
-		{"Cannot update cache", &mockClient{}, 0, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
 		{"Cannot inspect", &mockClient{inspectFail: true}, 1, []string{"opensuse:13.2", "new:1.0.0"}, true, "could not inspect image 'opensuse:13.2': inspect fail", ""},
 		{"Patch success", &mockClient{listReturnOneImage: true}, 0, []string{"opensuse:13.2", "new:1.0.0"}, true, "new:1.0.0 successfully created", ""},
 	}

--- a/ps.go
+++ b/ps.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/docker/api/types"
@@ -48,16 +47,9 @@ func psCmd(ctx *cli.Context) {
 		case <-killChannel:
 			return
 		default:
-			imageID, err := getImageID(container.Image)
-			if err != nil {
-				log.Printf("Cannot analyze container %s [%s]: %s", container.ID, container.Image, err)
-				unknown = append(unknown, container)
-				continue
-			}
-
-			if exists, suse := cache.idExists(imageID); exists && !suse {
+			if exists, suse := cache.idExists(container.ImageID); exists && !suse {
 				notSuse = append(notSuse, container)
-			} else if cache.isImageOutdated(imageID) {
+			} else if cache.isImageOutdated(container.ImageID) {
 				matches = append(matches, container)
 			} else {
 				unknown = append(unknown, container)

--- a/ps_test.go
+++ b/ps_test.go
@@ -65,19 +65,15 @@ func TestPsCommandMatches(t *testing.T) {
 	setupTestExitStatus()
 	safeClient.client = &mockClient{}
 
-	buffer := bytes.NewBuffer([]byte{})
-	log.SetOutput(buffer)
 	rec := capture.All(func() { psCmd(testContext([]string{}, false)) })
 
-	if !strings.Contains(buffer.String(), "Cannot analyze container 4 [foo]") {
-		t.Fatal("Wrong message")
-	}
-	if !strings.Contains(string(rec.Stdout), "Running containers whose images have been updated") {
+	if !strings.Contains(string(rec.Stdout), "Running containers whose images have been updated") &&
+		!strings.Contains(string(rec.Stdout), "busybox") {
 		t.Fatal("Wrong message")
 	}
 	if !strings.Contains(string(rec.Stdout), "The following containers have an unknown state") &&
-		!strings.Contains(string(rec.Stdout), "busybox") &&
-		!strings.Contains(string(rec.Stdout), "foo") {
+		!strings.Contains(string(rec.Stdout), "foo") &&
+		!strings.Contains(string(rec.Stdout), "35ae93c88cf8ab18da63bb2ad2dfd2399d745f292a344625fbb65892b7c25a01") {
 		t.Fatal("Wrong message")
 	}
 	if !strings.Contains(string(rec.Stdout), "The following containers have been ignored") &&

--- a/updates_test.go
+++ b/updates_test.go
@@ -25,7 +25,6 @@ func TestUpdateCommand(t *testing.T) {
 		{"List Command fails", &mockClient{listFail: true}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot proceed safely: List Failed", ""},
 		{"Overwrite detected", &mockClient{}, 1, []string{"ori", "opensuse:13.2"}, true, "Cannot overwrite an existing image. Please use a different repository/tag", ""},
 		{"Start fail on commit", &mockClient{startFail: true}, 1, []string{"ori", "new:1.0.0"}, true, "Could not commit to the new image: Start failed", ""},
-		{"Cannot update cache", &mockClient{}, 0, []string{"ori", "new:1.0.0"}, false, "Cannot add image details to zypper-docker cache", ""},
 		{"Update success", &mockClient{listReturnOneImage: true}, 0, []string{"opensuse:13.2", "new:1.0.0"}, true, "new:1.0.0 successfully created", ""},
 	}
 	cases.run(t, updateCmd, "zypper -n up", "")


### PR DESCRIPTION
Previously the docker psCmd function made use of getImageID
which expects a repo:tag combination, but was called with the
ID which the function was expected to return. Thus the call
of getImageID was redundant in this place.
The tests were updated to reflect the new behaviour.

Another problem that influenced zypper-docker ps was that
an image was not added to the outdated string in the cache
file after a zypper-docker up or patch if the image to be
updated was parsed with it's image ID.

Fixes: #144
Fixes: #145
Signed-off-by: Pascal Arlt <parlt@suse.com>