### PR TITLE
Update man pages to include new features

### DIFF
--- a/man/zypper-docker-lp.1.md
+++ b/man/zypper-docker-lp.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker list-patches \- List all the available patches.
 
@@ -19,12 +19,15 @@ same naming conventions as in Docker. To fetch which images are based on
 openSUSE or SUSE Linux Enterprise, use the **images** command.
 
 The **list-patches-container** takes the container ID and lists the patches for
-the image in which the given container is based on. Note that
-**list-patches-container** will not modify a running container. Instead of
-that, **zypper-docker** will spawn a new container based on the image in which
-the running container is based on.
+the given container. Note that **list-patches-container** will not modify a running
+container. Instead of that, **zypper-docker** will spawn a new container that will
+then be analyzed. **List-patches-container** is also able to analyze stopped containers.
+The **--base** flag can be used to analyze the base image of the container instead.
 
 # COMMAND OPTIONS
+**--base**
+  Analyze the base image of the container for patches.
+
 **--bugzilla[=#bug-id]**
   List available needed patches for all Bugzilla issues, or issues whose number matches the given string (--bugzilla=#).
 
@@ -45,3 +48,4 @@ the running container is based on.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v1.3.0 by Pascal Arlt <parlt@suse.com>

--- a/man/zypper-docker-lu.1.md
+++ b/man/zypper-docker-lu.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker list-updates \- List all the available updates.
 
@@ -18,11 +18,16 @@ given openSUSE/SUSE Linux Enterprise image. The provided image follows the
 same naming conventions as in Docker. To fetch which images are based on
 openSUSE or SUSE Linux Enterprise, use the **images** command.
 
-The **list-updates-container** takes the container ID and lists the updates for
-the image in which the given container is based on. Note that
-**list-updates-container** will not modify a running container. Instead of
-that, **zypper-docker** will spawn a new container based on the image in which
-the running container is based on.
+The **list-updates-container** command takes the container ID and lists the updates for
+the given container. Note that **list-updates-container** will not modify a running
+container. Instead of that, **zypper-docker** will spawn a new container that will
+then be analyzed. **List-updates-container** is also able to analyze stopped containers.
+The **--base** flag can be used to analyze the base image of the container instead.
+
+# COMMAND OPTIONS
+**--base**
+  Analyze the base image of the container for updates.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v1.3.0 by Pascal Arlt <parlt@suse.com>

--- a/man/zypper-docker-pchk.1.md
+++ b/man/zypper-docker-pchk.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker pchk \- Check for patches.
 
@@ -18,8 +18,15 @@ given openSUSE/SUSE Linux Enterprise image. The provided image follows the
 same naming conventions as in Docker. To fetch which images are based on
 openSUSE or SUSE Linux Enterprise, use the **images** command.
 
-The **patch-check-container** takes the container ID and lists the patches for
-the image in which the given container is based on.
+The **patch-check-container** command takes the container ID and checks the given
+container for patches. Note that **patch-check-container** will not modify a running
+container. Instead of that, **zypper-docker** will spawn a new container that will
+then be analyzed. **patch-check-container** is also able to analyze stopped containers.
+The **--base** flag can be used to analyze the base image of the container instead.
+
+# COMMAND OPTIONS
+**--base**
+  Execute a patch-check on the base image of the container.
 
 # EXIT CODES
 The **patch-check** command respects the same exit codes as provided by
@@ -37,3 +44,4 @@ exit codes:
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v1.3.0 by Pascal Arlt <parlt@suse.com>


### PR DESCRIPTION
The man pages now mention the ability to analyze changes made
to a running container as well as stopped containers.
The --base flag has been added.