### PR TITLE
Analyze container instead of base image by default

### DIFF
--- a/client.go
+++ b/client.go
@@ -465,11 +465,12 @@ func checkContainerRunning(id string) (types.Container, error) {
 	return container, nil
 }
 
-// checks whether a container with the given container ID exists.
-func checkContainerExists(containerID string) bool {
+// checks whether a container with the given container ID exists. If it
+// does return the container.
+func checkContainerExists(containerID string) (types.ContainerJSON, bool) {
 	client := getDockerClient()
-	_, err := client.ContainerInspect(context.Background(), containerID)
-	return err == nil
+	container, err := client.ContainerInspect(context.Background(), containerID)
+	return container, err == nil
 }
 
 // commitAndExecute commits the given container to a new image, executes the

--- a/flags.go
+++ b/flags.go
@@ -112,6 +112,12 @@ If the tag has not been provided, then "latest" is the one that will be used.`,
 
 Where <container-id> is either the container ID or the name of the container
 to be used.`,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "base",
+					Usage: "Analyze the base image of the container for updates.",
+				},
+			},
 		},
 		{
 			Name:    "update",
@@ -207,6 +213,10 @@ If the tag has not been provided, then "latest" is the one that will be used.`,
 Where <container-id> is either the container ID or the name of the container
 to be used.`,
 			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "base",
+					Usage: "Analyse the base image of the container for patches.",
+				},
 				cli.StringFlag{
 					Name:  "b, bugzilla",
 					Value: "",
@@ -313,6 +323,12 @@ If the tag has not been provided, then "latest" is the one that will be used.`,
 
 Where <container-id> is either the container ID or the name of the container
 to be used.`,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "base",
+					Usage: "Execute a patch-check on the base image of the container.",
+				},
+			},
 		},
 		{
 			Name:      "ps",

--- a/patch_check.go
+++ b/patch_check.go
@@ -32,6 +32,8 @@ func patchCheckContainerCmd(ctx *cli.Context) {
 // patchCheck calls the `zypper pchk` command for the given image and the given
 // arguments.
 func patchCheck(image string, ctx *cli.Context) error {
-	err := runStreamedCommand(image, "pchk", true)
+	err := runStreamedCommand(
+		image,
+		cmdWithFlags("pchk", ctx, []string{}, []string{"base"}), true)
 	return err
 }

--- a/patches.go
+++ b/patches.go
@@ -57,7 +57,7 @@ func listPatches(image string, ctx *cli.Context) error {
 
 	err := runStreamedCommand(
 		image,
-		cmdWithFlags("lp", ctx, []string{}, []string{}), true)
+		cmdWithFlags("lp", ctx, []string{}, []string{"base"}), true)
 	return err
 }
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -18,6 +18,7 @@ ZYPPERDOCKER="${ZYPPERDOCKER:-${INTEGRATION_ROOT}/../zypper-docker}"
 CONTAINER_ID=""
 TESTIMAGE="zypper-docker-integration-tests"
 TAG="latest"
+IMAGE_ID=$(docker images --no-trunc $TESTIMAGE:$TAG | awk '{print $3}' | tail -n1)
 
 function sane_run() {
   local cmd="$1"

--- a/test/patch_check.bats
+++ b/test/patch_check.bats
@@ -27,13 +27,13 @@ load helpers
 @test "zypper-docker patch-check-container" {
   # run a container
   run_container
+  zypperdocker pchkc --base $CONTAINER_ID
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Base image $IMAGE_ID of container $CONTAINER_ID will be analyzed. Manually installed packages won't be taken into account."+ ]]
+
   zypperdocker pchkc $CONTAINER_ID
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "WARNING: Only the source image from this container will be inspected. Manually installed packages won't be taken into account."+ ]]
-
-  zypperdocker -f pchkc $CONTAINER_ID
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ "WARNING: Force flag used. Manually installed packages will be analyzed as well."+ ]]
+  [[ "$output" =~ "Checking running container"+ ]]
 
   # stop the container
   stop_container

--- a/test/patches.bats
+++ b/test/patches.bats
@@ -47,13 +47,13 @@ load helpers
 @test "zypper-docker list-patches-container" {
   # run a container
   run_container
+  zypperdocker lpc --base $CONTAINER_ID
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Base image $IMAGE_ID of container $CONTAINER_ID will be analyzed. Manually installed packages won't be taken into account."+ ]]
+
   zypperdocker lpc $CONTAINER_ID
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "WARNING: Only the source image from this container will be inspected. Manually installed packages won't be taken into account."+ ]]
-
-  zypperdocker -f lpc $CONTAINER_ID
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ "WARNING: Force flag used. Manually installed packages will be analyzed as well."+ ]]
+  [[ "$output" =~ "Checking running container"+ ]]
 
   # stop the container
   stop_container

--- a/test/updates.bats
+++ b/test/updates.bats
@@ -45,13 +45,13 @@ load helpers
 @test "zypper-docker list-updates-container" {
   # run a container
   run_container
+  zypperdocker luc --base $CONTAINER_ID
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Base image $IMAGE_ID of container $CONTAINER_ID will be analyzed. Manually installed packages won't be taken into account."+ ]]
+
   zypperdocker luc $CONTAINER_ID
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "WARNING: Only the source image from this container will be inspected. Manually installed packages won't be taken into account."+ ]]
-
-  zypperdocker -f luc $CONTAINER_ID
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ "WARNING: Force flag used. Manually installed packages will be analyzed as well."+ ]]
+  [[ "$output" =~ "Checking running container"+ ]]
 
   # stop the container
   stop_container

--- a/updates.go
+++ b/updates.go
@@ -32,7 +32,9 @@ func listUpdatesContainerCmd(ctx *cli.Context) {
 // listUpdates lists all the updates available for the given image with the
 // given arguments.
 func listUpdates(image string, ctx *cli.Context) error {
-	err := runStreamedCommand(image, "lu", true)
+	err := runStreamedCommand(
+		image,
+		cmdWithFlags("lu", ctx, []string{}, []string{"base"}), true)
 	return err
 }
 


### PR DESCRIPTION
Committing running containers to a new image before analyzing
them with the zypper-docker luc, lpc and pchkc commands is now
the default. This way changes made to the running container will
always be included.
If the base image of a container should be analyzed, which was
the former default, a new --base flag can be used.
e.g. zypper-docker pchkc --base <container id>

Signed-off-by: Pascal Arlt <parlt@suse.com>