### PR TITLE
Fix zypper-docker up/patch --no-recommends

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -316,8 +316,11 @@ func updatePatchCmd(zypperCmd string, ctx *cli.Context) {
 		"replacefiles"}
 	toIgnore := []string{"author", "message"}
 
-	cmd := formatZypperCommand("ref", fmt.Sprintf("-n %v", zypperCmd), "clean -a")
+	cmd := formatZypperCommand("ref", fmt.Sprintf("-n %v", zypperCmd))
+	clean := formatZypperCommand("clean -a")
 	cmd = cmdWithFlags(cmd, ctx, boolFlags, toIgnore)
+	cmd += " && " + clean
+
 	newImgID, err := runCommandAndCommitToImage(
 		img,
 		repo,

--- a/test/patches.bats
+++ b/test/patches.bats
@@ -26,6 +26,13 @@ load helpers
 
   # remove created image
   docker rmi -f $TESTIMAGE:patched
+
+  zypperdocker patch --no-recommends $TESTIMAGE:$TAG $TESTIMAGE:patched
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$TESTIMAGE:patched successfully created"+ ]]
+
+  # remove created image
+  docker rmi -f $TESTIMAGE:patched
 }
 
 @test "zypper-docker list-patches" {

--- a/test/updates.bats
+++ b/test/updates.bats
@@ -25,6 +25,12 @@ load helpers
   [[ "$output" =~ "Cannot overwrite an existing image. Please use a different repository/tag"+ ]]
 
   docker rmi -f $TESTIMAGE:updated
+
+  zypperdocker up --no-recommends $TESTIMAGE:$TAG $TESTIMAGE:updated
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$TESTIMAGE:updated successfully created"+ ]]
+
+  docker rmi -f $TESTIMAGE:updated
 }
 
 @test "zypper-docker list-updates" {


### PR DESCRIPTION
The no-recommends flag was appended to zypper clean which caused
an error. Now the flag is used with zypper up/patch as intended.

Signed-off-by: Pascal Arlt <parlt@suse.com>