### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,31 @@
+Fri Jun 8 13:51:20 CET 2018 Pascal Arlt <parlt@suse.com>
+
+	* Release v2.0.0:
+		- Removed Go 1.5 and 1.6 support 1.9 and 1.10.x are supported now
+		  https://github.com/SUSE/zypper-docker/pull/139
+		- Add short forms of commands to help section
+		  https://github.com/SUSE/zypper-docker/pull/143
+		- Update and use zypper exit codes
+		  https://github.com/SUSE/zypper-docker/pull/122
+		- Move from docker/engine-api to docker/docker
+		  https://github.com/SUSE/zypper-docker/pull/138
+		- Allow inspection of stopped containers
+		  https://github.com/SUSE/zypper-docker/pull/137
+		- Fix bug that caused images not to be removed properly in some cases
+		  https://github.com/SUSE/zypper-docker/pull/137
+		- Fix bug that caused lpc command to log to stdout
+		  https://github.com/SUSE/zypper-docker/pull/140
+		- Fix bug that caused force flag not to work with zypper-docker images
+		  https://github.com/SUSE/zypper-docker/pull/141
+		- Fix docker ps command
+		  https://github.com/SUSE/zypper-docker/pull/146
+		- Fix bug with zypper-docker up/patch --no-recommends
+		  https://github.com/SUSE/zypper-docker/pull/150
+		- Update integration tests
+		  https://github.com/SUSE/zypper-docker/pull/142
+		- Analyze container instead of base image by default
+		  https://github.com/SUSE/zypper-docker/pull/148
+
 Tue Apr 26 15:07:31 CET 2016  Miquel Sabaté Solà <msabate@suse.com>
 
 	* Release v1.2:

--- a/cache.go
+++ b/cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/client_test.go
+++ b/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/flags.go
+++ b/flags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ var currentContext *cli.Context
 // Returns the version string
 func version() string {
 	const (
-		major = 1
-		minor = 2
+		major = 2
+		minor = 0
 		patch = 0
 	)
 	return fmt.Sprintf("%v.%v.%v", major, minor, patch)

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package main
 import "testing"
 
 func TestVersion(t *testing.T) {
-	if version() != "1.2.0" {
+	if version() != "2.0.0" {
 		t.Fatal("Wrong version")
 	}
 }

--- a/helpers.go
+++ b/helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/images.go
+++ b/images.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/images_test.go
+++ b/images_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/man/generate.go
+++ b/man/generate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/man/zypper-docker-images.1.md
+++ b/man/zypper-docker-images.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker images \- List all the images based on either openSUSE or SUSE
 Linux Enterprise.
@@ -16,3 +16,4 @@ This command does not accept any extra arguments or command options.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated vor v2.0.0 by Pascal Arlt <partl@suse.com>

--- a/man/zypper-docker-lp.1.md
+++ b/man/zypper-docker-lp.1.md
@@ -48,4 +48,4 @@ The **--base** flag can be used to analyze the base image of the container inste
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
-June 2018, updated for v1.3.0 by Pascal Arlt <parlt@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <parlt@suse.com>

--- a/man/zypper-docker-lu.1.md
+++ b/man/zypper-docker-lu.1.md
@@ -30,4 +30,4 @@ The **--base** flag can be used to analyze the base image of the container inste
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
-June 2018, updated for v1.3.0 by Pascal Arlt <parlt@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <parlt@suse.com>

--- a/man/zypper-docker-patch.1.md
+++ b/man/zypper-docker-patch.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker patch \- Install the available patches for the given image.
 
@@ -49,3 +49,4 @@ openSUSE/SUSE Linux Enterprise, use the **images** command.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <partl@suse.com>

--- a/man/zypper-docker-pchk.1.md
+++ b/man/zypper-docker-pchk.1.md
@@ -44,4 +44,4 @@ exit codes:
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
-June 2018, updated for v1.3.0 by Pascal Arlt <parlt@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <parlt@suse.com>

--- a/man/zypper-docker-ps.1.md
+++ b/man/zypper-docker-ps.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker ps \- List all the running containers that are outdated.
 
@@ -23,3 +23,4 @@ This command does not accept any extra arguments or command options.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <partl@suse.com>

--- a/man/zypper-docker-up.1.md
+++ b/man/zypper-docker-up.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker update \- Install the available updates for the given image.
 
@@ -37,3 +37,4 @@ openSUSE/SUSE Linux Enterprise, use the **images** command.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <partl@suse.com>

--- a/man/zypper-docker.1.md
+++ b/man/zypper-docker.1.md
@@ -1,6 +1,6 @@
 % ZYPPER-DOCKER(1) zypper-docker User manuals
 % SUSE LLC.
-% SEPTEMBER 2015
+% JUNE 2018
 # NAME
 zypper\-docker \- Patching Docker images safely
 
@@ -85,3 +85,4 @@ just run **man zypper-docker <command>**.
 
 # HISTORY
 September 2015, created by Miquel Sabaté Solà <msabate@suse.com>
+June 2018, updated for v2.0.0 by Pascal Arlt <partl@suse.com>

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patch_check.go
+++ b/patch_check.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patch_check_test.go
+++ b/patch_check_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patches.go
+++ b/patches.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/patches_test.go
+++ b/patches_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ps.go
+++ b/ps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ps_test.go
+++ b/ps_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/climate
+++ b/scripts/climate
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-# Copyright (C) 2014-2015 Miquel Sabaté Solà
+# Copyright (C) 2014-2018 Miquel Sabaté Solà
 # This file is licensed under the MIT license.
 # See the LICENSE file.
 

--- a/signals.go
+++ b/signals.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tty.go
+++ b/tty.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updates.go
+++ b/updates.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/updates_test.go
+++ b/updates_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zypper-docker.go
+++ b/zypper-docker.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zypper.go
+++ b/zypper.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/zypper_test.go
+++ b/zypper_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 SUSE LLC. All rights reserved.
+// Copyright (c) 2018 SUSE LLC. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Change zypper-docker's version from 1.2.0 to 2.0.0.
Update the licences from 2015 to 2018.
Update the man pages to June 2018.

Signed-off-by: Pascal Arlt <parlt@suse.com>