### PR TITLE
ci: use registry.opensuse.org

### DIFF
--- a/docker/Dockerfile-integration-tests
+++ b/docker/Dockerfile-integration-tests
@@ -1,1 +1,1 @@
-From opensuse/tumbleweed:latest
+FROM registry.opensuse.org/opensuse/tumbleweed:latest


### PR DESCRIPTION
Docker Hub has pull limits that break our CI.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>